### PR TITLE
ui: Fix a headerbar icon name

### DIFF
--- a/usr/share/hypnotix/hypnotix.ui
+++ b/usr/share/hypnotix/hypnotix.ui
@@ -31,7 +31,7 @@
                   <object class="GtkImage">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="icon_name">go-left-symbolic</property>
+                    <property name="icon_name">go-previous-symbolic</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
go-previous-symbolic is the proper icon name and actually gives us a symbolic
icon in the headerbar.