### PR TITLE
workaround for wayland

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1034,6 +1034,7 @@ class MainWindow():
 
         options["user_agent"] = self.settings.get_string("user-agent")
         options["referrer"] = self.settings.get_string("http-referer")
+        options["vo"] = "x11"
 
         self.mpv = mpv.MPV(**options, script_opts='osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=3', input_default_bindings=True, \
              input_vo_keyboard=True,osc=True, ytdl=True, wid=str(self.mpv_drawing_area.get_window().get_xid()))


### PR DESCRIPTION
Solves Issue #90. In wayland hypnotix now runs with:
$ GDK_BACKEND=x11 hypnotix

Explanation:
with "$ GDK_BACKEND=x11 hypnotix" hypnotix is forced to run in xwayland but when it launchs mpv this runs in Wayland and you get the error: "AttributeError: ‘GdkWaylandWindow’ object has no attribute ‘get_xid’". With "$ mpv -vo=x11 ..." mpv is forced to run in the x11 environment too.