### PR TITLE
Change distribution to the corresponding Ubuntu name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hypnotix (1.5) ulyssa; urgency=medium
+hypnotix (1.5) focal; urgency=medium
 
   [ freddii ]
   * Added Keywords to desktop file (#76)


### PR DESCRIPTION
Also see https://github.com/linuxmint/hypnotix/issues/125#issuecomment-813083332

I was not able to push the to a private ubuntu ppa repository, error message

```
Rejected:
Unable to find distroseries: ulyssa
Further error processing not possible because of a critical previous error.
```

Renaming the os from ulysses to focal allows this package to be published to the ubuntu ppa. Since Linux Mint is based on Ubuntu I am assuming this change will not affect the releases for Linux Mint, but please verify this first.
