### PR TITLE
Fix symlink target for irak.svg

### DIFF
--- a/usr/share/hypnotix/pictures/badges/irak.svg
+++ b/usr/share/hypnotix/pictures/badges/irak.svg
@@ -1,1 +1,1 @@
-/home/mtwebster/bin/hypnotix/usr/share/hypnotix/pictures/badges/iraq.svg
+iraq.svg


### PR DESCRIPTION
This is a small change that fixes the target for the iraq.svg symlink.

Closes https://github.com/linuxmint/hypnotix/issues/184