### PR TITLE
Use standard icon for Edit button

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -965,7 +965,7 @@ class MainWindow():
             button.set_relief(Gtk.ReliefStyle.NONE)
             button.connect("clicked", self.on_edit_button_clicked, provider)
             image = Gtk.Image()
-            image.set_from_icon_name("list-edit-symbolic", Gtk.IconSize.BUTTON)
+            image.set_from_icon_name("document-properties-symbolic", Gtk.IconSize.BUTTON)
             button.set_tooltip_text(_("Edit"))
             button.add(image)
             box.pack_start(button, False, False, 0)


### PR DESCRIPTION
`list-edit` is not standard icon name according to https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
Some systems don't have this icon. It leads to fallback `image-missing` icon on Edit button.