### PR TITLE
Fix error when the Content-Length header is missing

### DIFF
--- a/usr/lib/hypnotix/common.py
+++ b/usr/lib/hypnotix/common.py
@@ -161,7 +161,7 @@ class Manager():
                         # Set downloaded size
                         downloaded_bytes = 0
                         # Get total playlist byte size
-                        total_content_size = int(response.headers['content-length'])
+                        total_content_size = int(response.headers.get('content-length', 0))
                         # Set stream blocks
                         block_bytes = int(4*1024*1024)     # 4 MB
 

--- a/usr/lib/hypnotix/common.py
+++ b/usr/lib/hypnotix/common.py
@@ -161,7 +161,7 @@ class Manager():
                         # Set downloaded size
                         downloaded_bytes = 0
                         # Get total playlist byte size
-                        total_content_size = int(response.headers.get('content-length', 0))
+                        total_content_size = int(response.headers.get('content-length', 15))
                         # Set stream blocks
                         block_bytes = int(4*1024*1024)     # 4 MB
 


### PR DESCRIPTION
hypnotix raises `KeyError` when a valid playlist response does not have `Content-Length` header.

I propose to set `total_content_size = 0` when `Content-Length` header is missing.