### PR TITLE
debian/control: recommend yt-dlp

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,6 @@ Depends: gir1.2-xapp-1.0 (>= 2.6.0),
          libmpv1,
          python3-imdbpy,
          python3-gi-cairo
-Recommends: youtube-dl
+Recommends: yt-dlp | youtube-dl
 Description: IPTV Player
  Watch TV by streaming from M3U sources.


### PR DESCRIPTION
youtube-dl is obsolete