### PR TITLE
fix: ensure word is in the list 

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -511,7 +511,7 @@ class MainWindow:
         if " " not in string:
             return string
         words = string.split()
-        if word in string:
+        if word in words:
             words.remove(word)
         return " ".join(words)
 


### PR DESCRIPTION
Currently the if statement will be true for input
```
word: 'VOD', string: 'VOD: Some movie'
```
but then crash when trying to remove it from the list, since
`VOD` is not in the list, but rather `VOD:`.

Stacktrace:
```
Traceback (most recent call last):
  File "/nix/store/2v34x6pa77nh2xn7sz7jvf3zf9nzgj3m-hypnotix-3.5/lib/hypnotix/hypnotix.py", line 425, in show_groups
    label.set_text("%s (%d)" % (self.remove_word("VOD", group.name), len(group.channels)))
  File "/nix/store/2v34x6pa77nh2xn7sz7jvf3zf9nzgj3m-hypnotix-3.5/lib/hypnotix/hypnotix.py", line 515, in remove_word
    words.remove(word)
ValueError: list.remove(x): x not in list
```
