### PR TITLE
issue 342 - fix Romania flag

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -491,7 +491,7 @@ class MainWindow:
 
             found_flag = False
             for country_name in COUNTRY_CODES.keys():
-                if country_name.lower() in group.name.lower():
+                if country_name.lower() == group.name.lower():
                     found_flag = True
                     self.add_flag(COUNTRY_CODES[country_name], box)
                     break


### PR DESCRIPTION
issue 342 - Since Romania contains oman, the country code for Oman and thus the flag is used.
By using == we are ensuring that the full name of the country is checked.