### PR TITLE
Fix for Issue #348 - Xstream config erroring out on load

### DIFF
--- a/usr/lib/hypnotix/xtream.py
+++ b/usr/lib/hypnotix/xtream.py
@@ -626,7 +626,7 @@ class XTream:
                             if not skip_stream:
                                 # Some channels have no group,
                                 # so let's add them to the catch all group
-                                if stream_channel["category_id"] is None:
+                                if stream_channel["category_id"] == "":
                                     stream_channel["category_id"] = "9999"
                                 elif stream_channel["category_id"] != "1":
                                     pass

--- a/usr/lib/hypnotix/xtream.py
+++ b/usr/lib/hypnotix/xtream.py
@@ -626,10 +626,8 @@ class XTream:
                             if not skip_stream:
                                 # Some channels have no group,
                                 # so let's add them to the catch all group
-                                if stream_channel["category_id"] == "":
+                                if not stream_channel["category_id"]: 
                                     stream_channel["category_id"] = "9999"
-                                elif stream_channel["category_id"] != "1":
-                                    pass
 
                                 # Find the first occurence of the group that the
                                 # Channel or Stream is pointing to


### PR DESCRIPTION
After recent update to v4.6, my xtream config was erroring out on load and the app didn't load as described by @buconettin in the Issue #348 

This is a fix recommended in the comment, which I applied in my local, built and worked for me.