### PR TITLE
Add Channel - Confusing label in the German translation

### DIFF
--- a/po/hypnotix-de.po
+++ b/po/hypnotix-de.po
@@ -425,7 +425,7 @@ msgstr ""
 
 #: usr/share/hypnotix/hypnotix.ui.h:34
 msgid "Logo URL:"
-msgstr "Lokale Adresse:"
+msgstr "Logo Adresse:"
 
 #: usr/share/hypnotix/hypnotix.ui.h:35
 msgid "This channel will be added to your favorites."


### PR DESCRIPTION
Changed the Lokale Adresse to Logo Adresse for fix of german translation.