### PR TITLE
Fix encoding for m3u links, again

### DIFF
--- a/usr/lib/hypnotix/common.py
+++ b/usr/lib/hypnotix/common.py
@@ -179,8 +179,7 @@ class Manager:
                         # Set stream blocks
                         block_bytes = int(4 * 1024 * 1024)  # 4 MB
 
-                        if response.encoding is None:
-                            response.encoding = response.apparent_encoding
+                        response.encoding = response.encoding or response.apparent_encoding or "utf-8"
                         with open(provider.path, "w", encoding=response.encoding) as file:
                             # Grab data by block_bytes
                             for data in response.iter_content(block_bytes, decode_unicode=True):

--- a/usr/lib/hypnotix/common.py
+++ b/usr/lib/hypnotix/common.py
@@ -179,7 +179,9 @@ class Manager:
                         # Set stream blocks
                         block_bytes = int(4 * 1024 * 1024)  # 4 MB
 
-                        with open(provider.path, "w", encoding="utf-8") as file:
+                        if response.encoding is None:
+                            response.encoding = response.apparent_encoding
+                        with open(provider.path, "w", encoding=response.encoding) as file:
                             # Grab data by block_bytes
                             for data in response.iter_content(block_bytes, decode_unicode=True):
                                 downloaded_bytes += block_bytes


### PR DESCRIPTION
PR #340 was supposed to solve issue #339, but it caused a bigger problem - some new providers could not be added (#365).

Both of these issues have to do with what encodings providers use - some use `None` encoding, some have `apparent_encoding` different from the actual `encoding`:

![image.png](https://github.com/user-attachments/assets/65421a28-f517-42c6-a6b9-8379f273b6ec)
Playlist links: [test1](https://raw.githubusercontent.com/blackbirdstudiorus/LoganetXIPTV/main/LoganetXAll.m3u) and [test2](https://iptv-org.github.io/iptv/countries/ru.m3u)

In this PR both of the issues are fixed by specifying the response `encoding` if it's `None` and using this `encoding` when downloading playlists.