### PR TITLE
increase efficiency

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -499,9 +499,6 @@ class MainWindow:
                     self.add_flag(COUNTRY_CODES[country_name], box)
                     break
 
-            if not found_flag:
-                print(f"No flag found for: {group.name}")
-
             for word in name.split():
                 self.add_badge(word, box, added_words)
 
@@ -509,7 +506,8 @@ class MainWindow:
             box.set_spacing(6)
             button.add(box)
             self.categories_flowbox.add(button)
-            self.categories_flowbox.show_all()
+
+        self.categories_flowbox.show_all()
 
         if not found_groups:
             self.on_category_button_clicked(None, None)
@@ -712,6 +710,8 @@ class MainWindow:
         return surface
 
     def on_go_back_button(self, widget):
+        self.channels_listbox.set_filter_func(None)
+        self.channels_listbox.invalidate_filter()
         self.navigate_to(self.back_page)
         if self.active_channel is not None:
             self.playback_bar.show()
@@ -734,20 +734,9 @@ class MainWindow:
             GLib.timeout_add_seconds(0.1, self.on_search)
 
     def on_search(self):
-        def filter_func(child):
-            search_bar_text = unidecode(self.search_bar.get_text()).lower()
-            label_text = unidecode(child.get_children()[0].get_children()[0].get_children()[1].get_text()).lower()
-            if search_bar_text in label_text:
-                self.visible_search_results += 1
-                return True
-            else:
-                return False
-
         self.visible_search_results = 0
-        self.channels_listbox.set_filter_func(filter_func)
-        if not self.channels_listbox.get_children():
-            self.show_channels(self.active_provider.channels)
-        print("Filtering %d channel names containing the string '%s'..." % (len(self.channels_listbox.get_children()), self.latest_search_bar_text))
+        self.channels_listbox.invalidate_filter()
+        self.show_channels([channel for channel in self.active_provider.channels if self.latest_search_bar_text in channel.name.lower()])
         if self.visible_search_results == 0:
             self.status(_("No channels found"))
         else:


### PR DESCRIPTION
This aims to increase the efficiency of the code by changing several things. I personally use a provider with a lot of channels, and the application was unusable for me. I decided to dip into the code and see if anything could be changed.

First, I noticed that when categories were being displayed, the flowbox was being rendered for each individual category - there shouldn't be any reason this is required. Rendering everything once at the end is fine. Additionally, a good idea to add onto here would be to freeze the flowbox when adding the groups, and thaw after. That way all rendering is paused until all groups have been compiled. In the worst case, time required to display all groups was 15 seconds. This dropped down to 3 seconds on my computer.

The biggest change was how the search works. Currently, the channel listbox would show all the possible channels, then apply a filter to remove any we don't want. This was wasteful and largely unnecessary, since the required channels would be re-added back to the list if the user filtered by category. Usually when I used to search, I used to search for one specific channel I knew, and it would still try to show all channels, and then filter through them. To remedy this, only the channels that should appear to the user will now be passed to `show_channels`. Filtering this way is greatly better as it avoids looping through all possible channels in the provider. It avoids the need for images for channels that won't even be shows, and it avoids creating a new object while adding it to the listbox. If the user performed another search, we would only have the previous channels shown, so instead now we just redraw the channels that are required.
This has hugely improved the speed and performance for me. As I mentioned, I have a provider with a very large number of channels, so searching was the only reasonable way for me to get to where I want. And for each search, looping through all channels was just not feasible. It used to routinely take upwards of 3 to 4 minutes, after which I'd give up. This is now basically instantaneous.

However, I feel the best way forward would be to add a scroll listener and dynamically load channels when they are required.