### PR TITLE
Allow for '=' on values of mpv options

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1689,7 +1689,7 @@ class MainWindow:
             if ("=") in mpv_options:
                 pairs = mpv_options.split()
                 for pair in pairs:
-                    key, value = pair.split("=")
+                    key, value = pair.split("=", 1)
                     options[key] = value
         except Exception as e:
             print("Could not parse MPV options!")


### PR DESCRIPTION
This allows for mpv options with "=" in their values. E.g. `audio-device=alsa/default:CARD=sndrpihifiberry`.
Tested on aarch64 Raspberry Pi OS (based on Debian 12)