### PR TITLE
Fix downloading m3u get "b'xxx'" string in files

### DIFF
--- a/usr/lib/hypnotix/common.py
+++ b/usr/lib/hypnotix/common.py
@@ -185,7 +185,13 @@ class Manager:
                             for data in response.iter_content(block_bytes, decode_unicode=True):
                                 downloaded_bytes += block_bytes
                                 print("{} bytes".format(downloaded_bytes))
-                                file.write(str(data))
+                                # if data is still bytes, decode it
+                                if isinstance(data, bytes):
+                                    data = data.decode('utf-8', errors='ignore')
+                                else:
+                                    data = str(data)
+                                # Write data to file
+                                file.write(data)
                         if downloaded_bytes < total_content_size:
                             print("The file size is incorrect, deleting")
                             os.remove(provider.path)


### PR DESCRIPTION
Sometimes the link of m3u just return a file-downloading thing. Thus the file may not be string already, but still bytes.

Then the m3u file can not be parsed correctly.