### PR TITLE
Optimize: Avoid reinitializing MPV on every playback

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -899,8 +899,9 @@ class MainWindow:
             # self.mpv_drawing_area.show()
             self.info_menu_item.set_sensitive(False)
             self.before_play(channel)
-            self.reinit_mpv()
-            self.mpv.play(channel.url)
+            while self.mpv is None:
+                time.sleep(0.01)
+            self.mpv.command("loadfile", channel.url, "replace", f"media-title={channel.name}")
             self.mpv.wait_until_playing()
             self.after_play(channel)
 

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -901,7 +901,7 @@ class MainWindow:
             self.before_play(channel)
             while self.mpv is None:
                 time.sleep(0.01)
-            self.mpv.command("loadfile", channel.url, "replace", f"media-title={channel.name}")
+            self.mpv.command("loadfile", channel.url, "replace", f"force-media-title={channel.name}")
             self.mpv.wait_until_playing()
             self.after_play(channel)
 


### PR DESCRIPTION
play_async uses the mpv loadfile command instead of recreating a new mpv instance on each play