### PR TITLE
Fixed massive memory leak

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -949,6 +949,16 @@ class MainWindow:
         self.monitor_playback()
 
     def monitor_playback(self):
+        try:
+            self.mpv.unobserve_property("video-params", self.on_video_params)
+            self.mpv.unobserve_property("video-format", self.on_video_format)
+            self.mpv.unobserve_property("audio-params", self.on_audio_params)
+            self.mpv.unobserve_property("audio-codec", self.on_audio_codec)
+            self.mpv.unobserve_property("video-bitrate", self.on_bitrate)
+            self.mpv.unobserve_property("audio-bitrate", self.on_bitrate)
+            self.mpv.unobserve_property("core-idle", self.on_playback_changed)
+        except:
+            pass
         self.mpv.observe_property("video-params", self.on_video_params)
         self.mpv.observe_property("video-format", self.on_video_format)
         self.mpv.observe_property("audio-params", self.on_audio_params)
@@ -1700,15 +1710,17 @@ class MainWindow:
             # To prevent 'multiple values for keyword argument'!
             osc = options.pop("osc") != "no"
 
-        self.mpv = mpv.MPV(
-            **options,
-            script_opts="osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=3",
-            input_default_bindings=True,
-            input_vo_keyboard=True,
-            osc=osc,
-            ytdl=True,
-            wid=str(self.mpv_drawing_area.get_window().get_xid())
-        )
+        if self.mpv is None:
+            self.mpv = mpv.MPV(
+                **options,
+                script_opts="osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=3",
+                input_default_bindings=True,
+                input_vo_keyboard=True,
+                osc=osc,
+                ytdl=True,
+                wid=str(self.mpv_drawing_area.get_window().get_xid())
+            )
+
         self.mpv.volume = self.volume
         self.mpv.observe_property("volume", self.on_volume_prop)
 


### PR DESCRIPTION
Let's say you have 20 streams in the sidebar and you keep on pressing the arrow keys going back and/or forth: each time you load another URL a new instance of mpv class is created, and you can see the memory usage skyrocketing very quickly. This fix creates just one instance of mpv, instead, and unobserves the previous stream properties.