### PR TITLE
Added F8 as shortcut for play/pause

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1539,6 +1539,9 @@ class MainWindow:
             self.theather_mode()
         elif event.keyval == Gdk.KEY_F7:
             self.borderless_mode()
+        elif event.keyval == Gdk.KEY_F8:
+            self.on_pause_button(widget)
+            return True
         elif event.keyval == Gdk.KEY_Escape:
             self.normal_mode()
         elif event.keyval == Gdk.KEY_BackSpace and not ctrl and type(widget.get_focus()) != gi.repository.Gtk.SearchEntry:


### PR DESCRIPTION
By default, you can play/pause mpv using the spacebar: however, in Hypnotix you can't because you could need to type a space in the search field (for example). F8 seems to be ok.