### PR TITLE
Set mpv video output to 'x11' by default

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1622,6 +1622,8 @@ class MainWindow:
         if self.mpv is not None:
             self.mpv.stop()
         options = {}
+        options["vo"] = "x11"
+
         try:
             mpv_options = self.settings.get_string("mpv-options")
             if ("=") in mpv_options:


### PR DESCRIPTION
This ensures that the video output is always embedded into the main window.

Closes: https://github.com/linuxmint/hypnotix/issues/198