### PR TITLE
Use GDK_BACKEND environment variable to select x11 backend

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -12,8 +12,7 @@ from functools import partial
 from pathlib import Path
 
 # Force X11 on a Wayland session
-if "WAYLAND_DISPLAY" in os.environ:
-    os.environ["WAYLAND_DISPLAY"] = ""
+os.environ["GDK_BACKEND"] = "x11"
 
 # Suppress GTK deprecation warnings
 warnings.filterwarnings("ignore")


### PR DESCRIPTION
This is more reliable than unsetting WAYLAND_DISPLAY.