### PR TITLE
Set prgname to match with the executable

### DIFF
--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -104,6 +104,7 @@ class MyApplication(Gtk.Application):
     # Main initialization routine
     def __init__(self, application_id, flags):
         Gtk.Application.__init__(self, application_id=application_id, flags=flags)
+        GLib.set_prgname("hypnotix")
         self.connect("activate", self.activate)
 
     def activate(self, application):


### PR DESCRIPTION
This ensures that application launchers could match the window with the .desktop file and show the appropriate icon for them.