### PR TITLE
VLC backend as an additional optional Playback backend

### DIFF
--- a/usr/lib/hypnotix/common.py
+++ b/usr/lib/hypnotix/common.py
@@ -4,7 +4,9 @@ import re
 import threading
 
 import requests
-from gi.repository import GLib, GObject
+from gi.repository import GLib, GObject, Gtk
+import gettext
+_ = gettext.gettext
 
 # M3U parsing regex
 PARAMS = re.compile(r'(\S+)="(.*?)"')
@@ -35,6 +37,12 @@ def idle_function(func):
 
     return wrapper
 
+def set_playback_button_state(button: Gtk.Button, is_paused: bool):
+    """Updates a button's icon and tooltip based on the paused state."""
+    icon = "media-playback-start-symbolic" if is_paused else "media-playback-pause-symbolic"
+    tooltip = _("Play") if is_paused else _("Pause")
+    button.set_image(Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON))
+    button.set_tooltip_text(tooltip)
 
 def slugify(string):
     """

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -127,7 +127,6 @@ class MainWindow:
 
         self.application = application
         self.settings = Gio.Settings(schema_id="org.x.hypnotix")
-        self.icon_theme = Gtk.IconTheme.get_default()
         self.manager = Manager(self.settings)
         self.providers = []
         self.favorite_data = []
@@ -177,7 +176,6 @@ class MainWindow:
         )
 
         # Prefs variables
-        self.selected_pref_provider = None
         self.edit_mode = False
 
         # Create variables to quickly access dynamic widgets
@@ -525,10 +523,8 @@ class MainWindow:
             name = group.name.lower().replace("(", " ").replace(")", " ")
             added_words = []
 
-            found_flag = False
             for country_name in COUNTRY_CODES.keys():
                 if country_name.lower() == group.name.lower():
-                    found_flag = True
                     self.add_flag(COUNTRY_CODES[country_name], box)
                     break
 
@@ -1592,9 +1588,8 @@ class MainWindow:
 
         # Determine the actively pressed modifier
         modifier = event.get_state() & persistant_modifiers
-        # Bool of Control or Shift modifier states
+        # Bool of Control modifier state
         ctrl = modifier == Gdk.ModifierType.CONTROL_MASK
-        shift = modifier == Gdk.ModifierType.SHIFT_MASK
 
         if ctrl and event.keyval == Gdk.KEY_r:
             self.reload(page=None, refresh=True)
@@ -1828,8 +1823,6 @@ class MainWindow:
         if getattr(self, "mouse_poll_timer_id", 0) > 0:
             GLib.source_remove(self.mouse_poll_timer_id)
             self.mouse_poll_timer_id = 0
-        if getattr(self, "vlc_gui", None) is not None:
-            self.vlc_gui.mouse_cursor_visible = True
         self.window.unfullscreen()
         self.mpv_top_box.show()
         self.mpv_bottom_box.hide()

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1672,10 +1672,13 @@ class MainWindow:
         if self.mpv is not None:
             self.mpv.stop()
 
-        while not self.mpv_drawing_area.get_window() and not Gtk.events_pending():
-            time.sleep(0.1)
-
         if self.mpv is None:
+            # Map the player page if not realized yet
+            if not self.mpv_drawing_area.get_window():
+                self.mpv_stack.set_visible_child_name("player_page")
+                while not self.mpv_drawing_area.get_window():
+                    time.sleep(0.05)
+
             chosen_backend = self.settings.get_string("video-backend")
             xid = str(self.mpv_drawing_area.get_window().get_xid())
 
@@ -1719,12 +1722,11 @@ class MainWindow:
 
     def normal_mode(self):
         self.window.get_window().set_cursor(None)
+        if getattr(self, "vlc_gui", None) is not None:
+            self.vlc_gui.mouse_cursor_visible = True
         self.window.unfullscreen()
         self.mpv_top_box.show()
-        if self.settings.get_string("video-backend") == "vlc":
-            self.mpv_bottom_box.show()
-        else:
-            self.mpv_bottom_box.hide()
+        self.mpv_bottom_box.hide()
         if self.content_type == TV_GROUP:
             self.sidebar.show()
         self.headerbar.show()
@@ -1760,6 +1762,8 @@ class MainWindow:
             self.fullscreen = not self.fullscreen
             if self.fullscreen:
                 self.window.get_window().set_cursor(Gdk.Cursor.new_from_name(Gdk.Display.get_default(), "none"))
+                if getattr(self, "vlc_gui", None) is not None:
+                    self.vlc_gui.mouse_cursor_visible = False
                 # Fullscreen mode
                 self.window.fullscreen()
                 self.mpv_top_box.hide()

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -31,7 +31,7 @@ import setproctitle
 from unidecode import unidecode
 
 from common import Manager, Provider, Channel, MOVIES_GROUP, PROVIDERS_PATH, SERIES_GROUP, TV_GROUP,\
-    async_function, idle_function
+    async_function, idle_function, set_playback_button_state
 
 
 setproctitle.setproctitle("hypnotix")
@@ -955,7 +955,7 @@ class MainWindow:
             self.favorite_button.set_active(False)
             self.favorite_button_image.set_from_icon_name("xsi-non-starred-symbolic", Gtk.IconSize.BUTTON)
             self.favorite_button.set_tooltip_text(_("Add to favorites"))
-        self.update_pause_button(False)
+        set_playback_button_state(self.pause_button, False)
         self.page_is_loading = False
 
     @idle_function
@@ -1082,15 +1082,9 @@ class MainWindow:
         self.info_menu_item.set_sensitive(False)
         self.playback_bar.hide()
 
-    def update_pause_button(self, is_paused: bool):
-        icon = "media-playback-start-symbolic" if is_paused else "media-playback-pause-symbolic"
-        tooltip = _("Play") if is_paused else _("Pause")
-        self.pause_button.set_image(Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON))
-        self.pause_button.set_tooltip_text(tooltip)
-
     def on_pause_button(self, widget):
         self.mpv.pause = not self.mpv.pause
-        self.update_pause_button(self.mpv.pause)
+        set_playback_button_state(self.pause_button, self.mpv.pause)
 
     def on_show_button(self, widget):
         self.navigate_to("channels_page")

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1677,6 +1677,15 @@ class MainWindow:
                         btn_stop.connect("clicked", lambda w: self.on_stop_button(None))
                         self.vlc_control_layout.pack_start(btn_stop, False, False, 5)
 
+                        # THE SANDWICH MENU BUTTON (Audio, Video, Subtitle streams)
+                        btn_menu = Gtk.MenuButton()
+                        btn_menu.set_image(Gtk.Image.new_from_icon_name("open-menu-symbolic", Gtk.IconSize.BUTTON))
+                        btn_menu.set_direction(Gtk.ArrowType.UP)
+                        self.vlc_stream_menu = Gtk.Menu()
+                        btn_menu.set_popup(self.vlc_stream_menu)
+                        btn_menu.connect("toggled", lambda w: self.on_vlc_menu_toggled(btn_menu))
+                        self.vlc_control_layout.pack_start(btn_menu, False, False, 5)
+
                         self.mpv_bottom_box.pack_start(self.vlc_control_layout, True, True, 5)
 
                     self.mpv_bottom_box.show_all()
@@ -1702,6 +1711,50 @@ class MainWindow:
         else:
             self.mpv.set_engine_pause()
             self.btn_toggle.set_image(Gtk.Image.new_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.BUTTON))
+
+    def on_vlc_menu_toggled(self, menu_button):
+        if not menu_button.get_active() or not self.mpv or not hasattr(self.mpv, "player"):
+            return
+
+        for child in self.vlc_stream_menu.get_children():
+            self.vlc_stream_menu.remove(child)
+
+        player = self.mpv.player
+
+        stream_categories = [
+            ("Audio", player.audio_get_track_description, player.audio_get_track, player.audio_set_track),
+            ("Video", player.video_get_track_description, player.video_get_track, player.video_set_track),
+            ("Subtitles", player.video_get_spu_description, player.video_get_spu, player.video_set_spu),
+        ]
+
+        for label, get_desc, get_curr, set_track in stream_categories:
+            root_item = Gtk.MenuItem(label=label)
+            submenu = Gtk.Menu()
+            root_item.set_submenu(submenu)
+            self.vlc_stream_menu.append(root_item)
+
+            tracks = get_desc() or []
+            current_track_id = get_curr()
+
+            # Ensure an option to disable the stream is always available
+            if not any(tid == -1 for tid, _ in tracks):
+                tracks.insert(0, (-1, b"Disable"))
+
+            group = None
+            for track_id, track_name in tracks:
+                name_str = track_name.decode("utf-8", "ignore") if isinstance(track_name, bytes) else str(track_name)
+
+                item = Gtk.RadioMenuItem(group=group, label=name_str)
+                if group is None:
+                    group = item
+
+                if track_id == current_track_id:
+                    item.set_active(True)
+
+                item.connect("activate", lambda w, fn=set_track, tid=track_id: fn(tid) if w.get_active() else None)
+                submenu.append(item)
+
+        self.vlc_stream_menu.show_all()
 
     def on_mpv_drawing_area_draw(self, widget, cr):
         cr.set_source_rgb(0.0, 0.0, 0.0)

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1783,7 +1783,7 @@ class MainWindow:
 
             if chosen_backend == "vlc":
                 from player import VlcEngine
-                self.mpv = VlcEngine(gui=self.vlc_gui)
+                self.mpv = VlcEngine(gui=self.vlc_gui, settings=self.settings)
                 self.vlc_gui.show_controls()
             else:
                 options = {}

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -927,18 +927,29 @@ class MainWindow:
 
     @async_function
     def play_async(self, channel):
-        if self.mpv is not None:
-            self.mpv.stop()
-            self.mpv.pause = False
+        try:
+            if self.mpv is not None:
+                self.mpv.show_osd_text("", 1)
+                self.mpv.stop()
+                self.mpv.pause = False
+        except Exception:
+            pass
+
         print("CHANNEL: '%s' (%s)" % (channel.name, channel.url))
+
         if channel is not None and channel.url is not None:
-            # os.system("mpv --wid=%s %s &" % (self.wid, channel.url))
-            # self.mpv_drawing_area.show()
-            self.info_menu_item.set_sensitive(False)
             self.before_play(channel)
-            self.reinit_mpv()
-            self.mpv.play(channel.url)
-            self.mpv.wait_until_playing()
+
+            try:
+                self.reinit_mpv()
+                self.mpv.play(channel.url)
+                self.mpv.wait_until_playing()
+            except Exception as e:
+                # Silently catch ShutdownError if the user clicked a new channel
+                # or closed the app before this thread finished loading.
+                print(f"Playback interrupted or stopped: {e}")
+                return
+
             self.after_play(channel)
 
     @idle_function
@@ -971,6 +982,7 @@ class MainWindow:
             self.favorite_button_image.set_from_icon_name("xsi-non-starred-symbolic", Gtk.IconSize.BUTTON)
             self.favorite_button.set_tooltip_text(_("Add to favorites"))
         set_playback_button_state(self.pause_button, False)
+        self.info_menu_item.set_sensitive(False)
         self.page_is_loading = False
 
     @idle_function

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -24,8 +24,6 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("XApp", "1.0")
 from gi.repository import Gtk, Gdk, Gio, XApp, GdkPixbuf, GLib, Pango
 
-from player import MpvEngine, VlcEngine
-from vlcgui import VLCGUIController
 import requests
 import setproctitle
 from unidecode import unidecode
@@ -333,15 +331,21 @@ class MainWindow:
         self.bind_setting_widget("http-referer", self.referer_entry)
         self.bind_setting_widget("mpv-options", self.mpv_entry)
 
-        try:
-            import vlc
-            self.is_vlc_available = True
-        except ImportError:
-            self.is_vlc_available = False
+        import player
+        self.is_mpv_available = player.mpv is not None
+        self.is_vlc_available = player.vlc is not None
+
+        if not self.is_mpv_available and not self.is_vlc_available:
+            print("Error: Neither MPV nor VLC backend is available. Please install at least one.", file=sys.stderr)
+            sys.exit(1)
+
+        if self.is_vlc_available:
+            from vlcgui import VLCGUIController
 
         # Video Backend combo box (in preferences, alongside mpv-options)
         backend_model = Gtk.ListStore(str, str)
-        backend_model.append(["mpv", _("MPV (Default)")])
+        if self.is_mpv_available:
+            backend_model.append(["mpv", _("MPV (Default)")])
         if self.is_vlc_available:
             backend_model.append(["vlc", _("VLC Player")])
 
@@ -1758,17 +1762,29 @@ class MainWindow:
                     timeout -= 1
 
             chosen_backend = self.settings.get_string("video-backend")
+
+            if self.is_mpv_available and self.is_vlc_available:
+                if chosen_backend not in ["mpv", "vlc"]:
+                    chosen_backend = "mpv"
+            elif self.is_mpv_available:
+                if chosen_backend == "vlc":
+                    print("VLC backend is not available! Falling back to MPV.")
+                chosen_backend = "mpv"
+            elif self.is_vlc_available:
+                if chosen_backend == "mpv":
+                    print("MPV backend is not available! Falling back to VLC.")
+                chosen_backend = "vlc"
+            else:
+                print("Error: No media backend is available!", file=sys.stderr)
+                sys.exit(1)
+
             xid = str(self.mpv_drawing_area.get_window().get_xid())
 
             if chosen_backend == "vlc":
-                if getattr(self, "is_vlc_available", False) and self.vlc_gui is not None:
-                    self.mpv = VlcEngine(gui=self.vlc_gui)
-                    self.vlc_gui.show_controls()
-                else:
-                    print("VLC Python bindings missing! Falling back to default MPV.")
-                    chosen_backend = "mpv"
-
-            if chosen_backend != "vlc":
+                from player import VlcEngine
+                self.mpv = VlcEngine(gui=self.vlc_gui)
+                self.vlc_gui.show_controls()
+            else:
                 options = {}
                 try:
                     mpv_options = self.settings.get_string("mpv-options")
@@ -1786,6 +1802,7 @@ class MainWindow:
                     # To prevent 'multiple values for keyword argument'!
                     osc = options.pop("osc") != "no"
 
+                from player import MpvEngine
                 self.mpv = MpvEngine(options=options, osc=osc)
             self.mpv.set_window(xid)
 

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -34,9 +34,14 @@ from common import Manager, Provider, Channel, MOVIES_GROUP, PROVIDERS_PATH, SER
 
 setproctitle.setproctitle("hypnotix")
 
+# Setup dynamic paths based on the script's location
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+PREFIX = os.path.abspath(os.path.join(SCRIPT_DIR, "../../"))
+PKG_DATA_DIR = os.path.join(PREFIX, "share", "hypnotix")
+LOCALE_DIR = os.path.join(PREFIX, "share", "locale")
+
 # i18n
 APP = "hypnotix"
-LOCALE_DIR = "/usr/share/locale"
 locale.bindtextdomain(APP, LOCALE_DIR)
 gettext.bindtextdomain(APP, LOCALE_DIR)
 gettext.textdomain(APP)
@@ -70,7 +75,7 @@ AUDIO_SAMPLE_FORMATS = {
 }
 
 COUNTRY_CODES = {}
-with open("/usr/share/hypnotix/countries.list") as f:
+with open(os.path.join(PKG_DATA_DIR, "countries.list")) as f:
     for line in f:
         line = line.strip()
         code, name = line.split(":")
@@ -151,7 +156,7 @@ class MainWindow:
         # Used for redownloading timer
         self.reload_timeout_sec = 60 * 5
         self._timerid = -1
-        gladefile = "/usr/share/hypnotix/hypnotix.ui"
+        gladefile = os.path.join(PKG_DATA_DIR, "hypnotix.ui")
         self.builder = Gtk.Builder()
         self.builder.set_translation_domain(APP)
         self.builder.add_from_file(gladefile)
@@ -163,7 +168,7 @@ class MainWindow:
         self.info_window = self.builder.get_object("stream_info_window")
 
         provider = Gtk.CssProvider()
-        provider.load_from_path("/usr/share/hypnotix/hypnotix.css")
+        provider.load_from_path(os.path.join(PKG_DATA_DIR, "hypnotix.css"))
         screen = Gdk.Display.get_default_screen(Gdk.Display.get_default())
         # I was unable to found instrospected version of this
         Gtk.StyleContext.add_provider_for_screen(
@@ -437,9 +442,9 @@ class MainWindow:
         self.provider_type_combo.set_active(0)  # Select 1st type
         self.provider_type_combo.connect("changed", self.on_provider_type_combo_changed)
 
-        self.tv_logo.set_from_surface(self.get_surface_for_file("/usr/share/hypnotix/pictures/tv.svg", 258, 258))
-        self.movies_logo.set_from_surface(self.get_surface_for_file("/usr/share/hypnotix/pictures/movies.svg", 258, 258))
-        self.series_logo.set_from_surface(self.get_surface_for_file("/usr/share/hypnotix/pictures/series.svg", 258, 258))
+        self.tv_logo.set_from_surface(self.get_surface_for_file(os.path.join(PKG_DATA_DIR, "pictures/tv.svg"), 258, 258))
+        self.movies_logo.set_from_surface(self.get_surface_for_file(os.path.join(PKG_DATA_DIR, "pictures/movies.svg"), 258, 258))
+        self.series_logo.set_from_surface(self.get_surface_for_file(os.path.join(PKG_DATA_DIR, "pictures/series.svg"), 258, 258))
 
         self.reload(page="landing_page")
 
@@ -485,7 +490,7 @@ class MainWindow:
     def add_badge(self, word, box, added_words):
         if word not in added_words:
             for extension in ["svg", "png"]:
-                path = "/usr/share/hypnotix/pictures/badges/%s.%s" % (word, extension)
+                path = os.path.join(PKG_DATA_DIR, "pictures", "badges", "%s.%s" % (word, extension))
                 if os.path.exists(path):
                     try:
                         image = self.get_surf_based_image(path, -1, 32)
@@ -755,7 +760,7 @@ class MainWindow:
             else:
                 surface = self.get_surface_for_file(path, 200, 200)
         except Exception:
-            surface = self.get_surface_for_file("/usr/share/hypnotix/generic_tv_logo.png", 22, 22)
+            surface = self.get_surface_for_file(os.path.join(PKG_DATA_DIR, "generic_tv_logo.png"), 22, 22)
         return surface
 
     def on_go_back_button(self, widget=None):
@@ -902,7 +907,7 @@ class MainWindow:
             self.headerbar.set_subtitle(_("Reset providers"))
 
     def open_keyboard_shortcuts(self, widget):
-        gladefile = "/usr/share/hypnotix/shortcuts.ui"
+        gladefile = os.path.join(PKG_DATA_DIR, "shortcuts.ui")
         builder = Gtk.Builder()
         builder.set_translation_domain(APP)
         builder.add_from_file(gladefile)

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -897,7 +897,7 @@ class MainWindow:
         window.show()
 
     def on_favorite_button_toggled(self, widget):
-        if self.page_is_loading or self.active_channel is None:
+        if self.page_is_loading or getattr(self, "active_channel", None) is None:
             return
 
         name = self.active_channel.name
@@ -905,10 +905,18 @@ class MainWindow:
         if widget.get_active() and data not in self.favorite_data:
             print (f"Adding {name} to favorites")
             self.favorite_data.append(data)
+
+            # Dynamically update the tooltip
+            self.favorite_button.set_tooltip_text(_("Remove from favorites"))
+
         elif widget.get_active() == False and data in self.favorite_data:
             print (f"Removing {name} from favorites")
             self.favorite_data.remove(data)
-        self.favorite_button_image.set_from_icon_name("xsi-starred-symbolic" if widget.get_active() else "non-xsi-starred-symbolic", Gtk.IconSize.BUTTON)
+
+            # Dynamically update the tooltip
+            self.favorite_button.set_tooltip_text(_("Add to favorites"))
+
+        self.favorite_button_image.set_from_icon_name("xsi-starred-symbolic" if widget.get_active() else "xsi-non-starred-symbolic", Gtk.IconSize.BUTTON)
         self.manager.save_favorites(self.favorite_data)
 
     def on_channel_activated(self, box, widget):
@@ -972,8 +980,12 @@ class MainWindow:
         self.label_channel_url.set_text(channel.url)
 
         self.page_is_loading = True
-        data = f"{channel.info}:::{channel.url}"
-        if data in self.favorite_data:
+
+        # Use prefix matching to ignore appended EPG/XMLTV metadata
+        data_prefix = f"{channel.info}:::{channel.url}"
+        existing_match = next((fav for fav in self.favorite_data if fav == data_prefix or fav.startswith(data_prefix + ":::")), None)
+
+        if existing_match:
             self.favorite_button.set_active(True)
             self.favorite_button_image.set_from_icon_name("xsi-starred-symbolic", Gtk.IconSize.BUTTON)
             self.favorite_button.set_tooltip_text(_("Remove from favorites"))

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -237,6 +237,7 @@ class MainWindow:
             "useragent_entry",
             "referer_entry",
             "mpv_entry",
+            "video_backend_combo",
             "mpv_link",
             "ytdlp_local_switch",
             "ytdlp_system_version_label",
@@ -328,6 +329,22 @@ class MainWindow:
         self.bind_setting_widget("http-referer", self.referer_entry)
         self.bind_setting_widget("mpv-options", self.mpv_entry)
 
+        # Video Backend combo box (in preferences, alongside mpv-options)
+        backend_model = Gtk.ListStore(str, str)
+        backend_model.append(["mpv", _("MPV (Default)")])
+        backend_model.append(["vlc", _("VLC Player")])
+        self.video_backend_combo.set_model(backend_model)
+        renderer = Gtk.CellRendererText()
+        self.video_backend_combo.pack_start(renderer, True)
+        self.video_backend_combo.add_attribute(renderer, "text", 1)
+
+        current_backend = self.settings.get_string("video-backend")
+        for i, row in enumerate(backend_model):
+            if row[0] == current_backend:
+                self.video_backend_combo.set_active(i)
+                break
+
+        self.video_backend_combo.connect("changed", self.on_video_backend_combo_changed)
         # ytdlp
         self.ytdlp_local_switch.set_active(self.settings.get_boolean("use-local-ytdlp"))
         self.ytdlp_local_switch.connect("notify::active", self.on_ytdlp_local_switch_activated)
@@ -640,6 +657,18 @@ class MainWindow:
 
     def on_entry_changed(self, widget, key):
         self.settings.set_string(key, widget.get_text())
+
+    def on_video_backend_combo_changed(self, combo):
+        model = combo.get_model()
+        active_iter = combo.get_active_iter()
+        if active_iter:
+            backend_id = model[active_iter][0]
+            if backend_id != self.settings.get_string("video-backend"):
+                self.settings.set_string("video-backend", backend_id)
+                if self.mpv is not None:
+                    self.on_stop_button(None)
+                    self.mpv = None
+                self.mpv_bottom_box.hide()
 
     def on_ytdlp_local_switch_activated(self, widget, data=None):
         self.settings.set_boolean("use-local-ytdlp", widget.get_active())

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -955,6 +955,7 @@ class MainWindow:
             self.favorite_button.set_active(False)
             self.favorite_button_image.set_from_icon_name("xsi-non-starred-symbolic", Gtk.IconSize.BUTTON)
             self.favorite_button.set_tooltip_text(_("Add to favorites"))
+        self.update_pause_button(False)
         self.page_is_loading = False
 
     @idle_function
@@ -1081,8 +1082,15 @@ class MainWindow:
         self.info_menu_item.set_sensitive(False)
         self.playback_bar.hide()
 
+    def update_pause_button(self, is_paused: bool):
+        icon = "media-playback-start-symbolic" if is_paused else "media-playback-pause-symbolic"
+        tooltip = _("Play") if is_paused else _("Pause")
+        self.pause_button.set_image(Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON))
+        self.pause_button.set_tooltip_text(tooltip)
+
     def on_pause_button(self, widget):
         self.mpv.pause = not self.mpv.pause
+        self.update_pause_button(self.mpv.pause)
 
     def on_show_button(self, widget):
         self.navigate_to("channels_page")

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1716,7 +1716,10 @@ class MainWindow:
         self.window.get_window().set_cursor(None)
         self.window.unfullscreen()
         self.mpv_top_box.show()
-        self.mpv_bottom_box.hide()
+        if self.settings.get_string("video-backend") == "vlc":
+            self.mpv_bottom_box.show()
+        else:
+            self.mpv_bottom_box.hide()
         if self.content_type == TV_GROUP:
             self.sidebar.show()
         self.headerbar.show()

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1671,28 +1671,9 @@ class MainWindow:
     def reinit_mpv(self):
         if self.mpv is not None:
             self.mpv.stop()
-        options = {}
-        try:
-            mpv_options = self.settings.get_string("mpv-options")
-            if ("=") in mpv_options:
-                pairs = mpv_options.split()
-                for pair in pairs:
-                    key, value = pair.split("=", 1)
-                    options[key] = value
-        except Exception as e:
-            print("Could not parse MPV options!")
-            print(e)
-
-        options["user_agent"] = self.settings.get_string("user-agent")
-        options["referrer"] = self.settings.get_string("http-referer")
 
         while not self.mpv_drawing_area.get_window() and not Gtk.events_pending():
             time.sleep(0.1)
-
-        osc = True
-        if "osc" in options:
-            # To prevent 'multiple values for keyword argument'!
-            osc = options.pop("osc") != "no"
 
         if self.mpv is None:
             chosen_backend = self.settings.get_string("video-backend")
@@ -1707,10 +1688,29 @@ class MainWindow:
                     chosen_backend = "mpv"
 
             if chosen_backend != "vlc":
+                options = {}
+                try:
+                    mpv_options = self.settings.get_string("mpv-options")
+                    if ("=") in mpv_options:
+                        pairs = mpv_options.split()
+                        for pair in pairs:
+                            key, value = pair.split("=", 1)
+                            options[key] = value
+                except Exception as e:
+                    print("Could not parse MPV options!")
+                    print(e)
+
+                osc = True
+                if "osc" in options:
+                    # To prevent 'multiple values for keyword argument'!
+                    osc = options.pop("osc") != "no"
+
                 self.mpv = MpvEngine(options=options, osc=osc)
             self.mpv.set_window(xid)
 
-        self.mpv.volume = self.volume
+        self.mpv["user-agent"] = self.settings.get_string("user-agent")
+        self.mpv["referrer"] = self.settings.get_string("http-referer")
+        self.mpv.set_volume(self.volume)
         self.mpv.observe_property("volume", self.on_volume_prop)
 
     def on_mpv_drawing_area_draw(self, widget, cr):

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -885,6 +885,14 @@ class MainWindow:
             self.before_play(channel)
             self.reinit_mpv()
             self.mpv.play(channel.url)
+
+            chosen_backend = self.settings.get_string("video-backend")
+
+            if chosen_backend == "vlc":
+                # Vlc does not give any way to control the playback
+                # So we implement a trivial UI elements
+                GLib.idle_add(self.mpv_bottom_box.show_all)
+
             self.mpv.wait_until_playing()
             self.after_play(channel)
 
@@ -1651,6 +1659,28 @@ class MainWindow:
             if chosen_backend == "vlc":
                 try:
                     self.mpv = VlcEngine()
+
+                    if not hasattr(self, "vlc_control_layout"):
+                        self.vlc_control_layout = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=15)
+                        self.vlc_control_layout.set_halign(Gtk.Align.CENTER)
+
+                        ctx = self.vlc_control_layout.get_style_context()
+                        ctx.add_class("osd")
+
+                        # THE DYNAMIC PLAY/PAUSE TOGGLE BUTTON
+                        self.btn_toggle = Gtk.Button.new_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.BUTTON)
+                        self.btn_toggle.connect("clicked", lambda w: self.on_vlc_toggle_clicked())
+                        self.vlc_control_layout.pack_start(self.btn_toggle, False, False, 5)
+
+                        # THE SIMPLE STOP BUTTON
+                        btn_stop = Gtk.Button.new_from_icon_name("media-playback-stop-symbolic", Gtk.IconSize.BUTTON)
+                        btn_stop.connect("clicked", lambda w: self.on_stop_button(None))
+                        self.vlc_control_layout.pack_start(btn_stop, False, False, 5)
+
+                        self.mpv_bottom_box.pack_start(self.vlc_control_layout, True, True, 5)
+
+                    self.mpv_bottom_box.show_all()
+
                 except ImportError:
                     print("VLC Python bindings missing! Falling back to default MPV.")
                     chosen_backend = "mpv"
@@ -1661,6 +1691,17 @@ class MainWindow:
 
         self.mpv.volume = self.volume
         self.mpv.observe_property("volume", self.on_volume_prop)
+
+    def on_vlc_toggle_clicked(self):
+        if not self.mpv:
+            return
+
+        if getattr(self.mpv, 'is_paused', lambda: False)():
+            self.mpv.set_engine_resume()
+            self.btn_toggle.set_image(Gtk.Image.new_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.BUTTON))
+        else:
+            self.mpv.set_engine_pause()
+            self.btn_toggle.set_image(Gtk.Image.new_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.BUTTON))
 
     def on_mpv_drawing_area_draw(self, widget, cr):
         cr.set_source_rgb(0.0, 0.0, 0.0)

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -332,19 +332,26 @@ class MainWindow:
         # Video Backend combo box (in preferences, alongside mpv-options)
         backend_model = Gtk.ListStore(str, str)
         backend_model.append(["mpv", _("MPV (Default)")])
-        backend_model.append(["vlc", _("VLC Player")])
+        try:
+            import vlc
+            backend_model.append(["vlc", _("VLC Player")])
+        except ImportError:
+            pass
         self.video_backend_combo.set_model(backend_model)
         renderer = Gtk.CellRendererText()
         self.video_backend_combo.pack_start(renderer, True)
         self.video_backend_combo.add_attribute(renderer, "text", 1)
 
         current_backend = self.settings.get_string("video-backend")
+        active_index = 0
         for i, row in enumerate(backend_model):
             if row[0] == current_backend:
-                self.video_backend_combo.set_active(i)
+                active_index = i
                 break
+        self.video_backend_combo.set_active(active_index)
 
         self.video_backend_combo.connect("changed", self.on_video_backend_combo_changed)
+
         # ytdlp
         self.ytdlp_local_switch.set_active(self.settings.get_boolean("use-local-ytdlp"))
         self.ytdlp_local_switch.connect("notify::active", self.on_ytdlp_local_switch_activated)

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -574,6 +574,12 @@ class MainWindow:
                 self.channels_listbox.add(ChannelWidget(channel, image))
 
             self.channels_listbox.show_all()
+
+            if self.active_channel is None:
+                self.channel_stack.set_visible_child_name("empty_page")
+                self.label_channel_name.set_text("")
+                self.label_channel_url.set_text("")
+
             self.visible_search_results = len(self.channels_listbox.get_children())
             if len(logos_to_refresh) > 0:
                 self.download_channel_logos(logos_to_refresh)
@@ -1115,11 +1121,15 @@ class MainWindow:
         self.audio_properties[_("General")][_("Codec")] = codec.split()[0]
 
     def on_stop_button(self, widget):
-        self.mpv.stop()
+        if self.mpv is not None:
+            self.mpv.stop()
         # self.mpv_drawing_area.hide()
         self.active_channel = None
         self.info_menu_item.set_sensitive(False)
         self.playback_bar.hide()
+        self.label_channel_name.set_text("")
+        self.label_channel_url.set_text("")
+        self.channel_stack.set_visible_child_name("empty_page")
 
     def on_pause_button(self, widget):
         self.mpv.pause = not self.mpv.pause

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -763,8 +763,6 @@ class MainWindow:
 
     def on_go_back_button(self, widget=None):
         self.navigate_to(self.back_page)
-        if self.active_channel is not None:
-            self.playback_bar.show()
         if self.active_group and self.back_page == "categories_page":
             self.init_channels_listbox()
 
@@ -813,6 +811,14 @@ class MainWindow:
         self.stack.set_visible_child_name(page)
         provider = self.active_provider
         self.back_page = "landing_page"
+
+        # channels_page already shows the live video itself; elsewhere, surface
+        # the bar so a channel left playing in the background can be stopped.
+        if page != "channels_page" and self.active_channel is not None:
+            self.playback_bar.show()
+        else:
+            self.playback_bar.hide()
+
         if page == "landing_page":
             self.headerbar.set_title("Hypnotix")
             self.headerbar.set_subtitle(_("Watch TV"))
@@ -843,7 +849,6 @@ class MainWindow:
                 self.headerbar.set_subtitle(_("Series"))
         elif page == "channels_page":
             self.fullscreen_button.show()
-            self.playback_bar.hide()
             if favorites:
                 self.headerbar.set_title("Hypnotix")
                 self.headerbar.set_subtitle(_("Favorites"))

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -143,6 +143,9 @@ class MainWindow:
         self.is_changing_channel = False
         self.page_is_loading = False # used to ignore signals while we set widget states
 
+        self.cursor_hide_timer_id = 0
+        self.mouse_poll_timer_id = 0
+
         self.video_properties = {}
         self.audio_properties = {}
         self.volume = 100
@@ -974,6 +977,11 @@ class MainWindow:
     @idle_function
     def before_play(self, channel):
         self.channel_stack.set_visible_child_name("channel_page")
+        if self.fullscreen:
+            self.sidebar.hide()
+            if getattr(self, "cursor_hide_timer_id", 0) > 0:
+                GLib.source_remove(self.cursor_hide_timer_id)
+            self.cursor_hide_timer_id = GLib.timeout_add(2000, self.hide_cursor)
         self.mpv_stack.set_visible_child_name("spinner_page")
         self.video_properties.clear()
         self.video_properties[_("General")] = {}
@@ -1148,6 +1156,17 @@ class MainWindow:
         self.label_channel_name.set_text("")
         self.label_channel_url.set_text("")
         self.channel_stack.set_visible_child_name("empty_page")
+        # if self.fullscreen and self.content_type == TV_GROUP:
+        #     self.sidebar.show()
+        if self.fullscreen:
+            gdk_win = self.window.get_window()
+            if gdk_win:
+                gdk_win.set_cursor(None)
+            if getattr(self, "cursor_hide_timer_id", 0) > 0:
+                GLib.source_remove(self.cursor_hide_timer_id)
+                self.cursor_hide_timer_id = 0
+            if self.content_type == TV_GROUP:
+                self.sidebar.show()
 
     def on_pause_button(self, widget):
         self.mpv.pause = not self.mpv.pause
@@ -1781,6 +1800,12 @@ class MainWindow:
 
     def normal_mode(self):
         self.window.get_window().set_cursor(None)
+        if getattr(self, "cursor_hide_timer_id", 0) > 0:
+            GLib.source_remove(self.cursor_hide_timer_id)
+            self.cursor_hide_timer_id = 0
+        if getattr(self, "mouse_poll_timer_id", 0) > 0:
+            GLib.source_remove(self.mouse_poll_timer_id)
+            self.mouse_poll_timer_id = 0
         if getattr(self, "vlc_gui", None) is not None:
             self.vlc_gui.mouse_cursor_visible = True
         self.window.unfullscreen()
@@ -1820,14 +1845,18 @@ class MainWindow:
         if self.stack.get_visible_child_name() == "channels_page":
             self.fullscreen = not self.fullscreen
             if self.fullscreen:
-                self.window.get_window().set_cursor(Gdk.Cursor.new_from_name(Gdk.Display.get_default(), "none"))
-                if getattr(self, "vlc_gui", None) is not None:
-                    self.vlc_gui.mouse_cursor_visible = False
                 # Fullscreen mode
                 self.window.fullscreen()
                 self.mpv_top_box.hide()
                 self.mpv_bottom_box.hide()
+                if not getattr(self, "mouse_poll_timer_id", 0):
+                    self.last_mouse_pos = None
+                    self.mouse_poll_timer_id = GLib.timeout_add(200, self.poll_mouse_position)
                 self.sidebar.hide()
+                if self.active_channel is not None:
+                    if getattr(self, "cursor_hide_timer_id", 0) > 0:
+                        GLib.source_remove(self.cursor_hide_timer_id)
+                    self.cursor_hide_timer_id = GLib.timeout_add(2000, self.hide_cursor)
                 self.headerbar.hide()
                 self.status_label.hide()
                 self.channels_box.set_border_width(0)
@@ -1842,6 +1871,53 @@ class MainWindow:
 
     def on_volume_prop(self, name, value ):
         self.volume = value
+
+    def poll_mouse_position(self):
+        if not self.fullscreen:
+            self.mouse_poll_timer_id = 0
+            return False
+
+        if getattr(self, "active_channel", None) is not None:
+            display = Gdk.Display.get_default()
+            seat = display.get_default_seat()
+            if seat:
+                pointer = seat.get_pointer()
+                screen, x, y = pointer.get_position()
+                if getattr(self, "last_mouse_pos", None) != (x, y):
+                    self.last_mouse_pos = (x, y)
+
+                    # Wake up cursor for the main window
+                    gdk_win = self.window.get_window()
+                    if gdk_win:
+                        gdk_win.set_cursor(None)
+
+                    # Wake up cursor for the MPV drawing area
+                    draw_win = self.mpv_drawing_area.get_window()
+                    if draw_win:
+                        draw_win.set_cursor(None)
+
+                    # Reset the hide countdown
+                    if getattr(self, "cursor_hide_timer_id", 0) > 0:
+                        GLib.source_remove(self.cursor_hide_timer_id)
+                    self.cursor_hide_timer_id = GLib.timeout_add(2000, self.hide_cursor)
+        return True
+
+    def hide_cursor(self):
+        if self.fullscreen and getattr(self, "active_channel", None) is not None:
+            hidden_cursor = Gdk.Cursor.new_from_name(Gdk.Display.get_default(), "none")
+
+            # Hide cursor for the main window
+            gdk_win = self.window.get_window()
+            if gdk_win:
+                gdk_win.set_cursor(hidden_cursor)
+
+            # Hide cursor for the MPV drawing area
+            draw_win = self.mpv_drawing_area.get_window()
+            if draw_win:
+                draw_win.set_cursor(hidden_cursor)
+
+        self.cursor_hide_timer_id = 0
+        return False
 
 if __name__ == "__main__":
     application = MyApplication("org.x.hypnotix", Gio.ApplicationFlags.FLAGS_NONE)

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -674,6 +674,7 @@ class MainWindow:
                 self.settings.set_string("video-backend", backend_id)
                 if self.mpv is not None:
                     self.on_stop_button(None)
+                    self.mpv.terminate()
                     self.mpv = None
                 self.mpv_bottom_box.hide()
 
@@ -1687,12 +1688,11 @@ class MainWindow:
 
             if chosen_backend == "vlc":
                 try:
-                    self.mpv = VlcEngine()
-
                     if not hasattr(self, "vlc_gui"):
                         self.vlc_gui = VLCGUIController(self)
                         self.vlc_gui.setup_ui()
 
+                    self.mpv = VlcEngine(gui=self.vlc_gui)
                     self.vlc_gui.show_controls()
 
                 except ImportError:

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -704,6 +704,8 @@ class MainWindow:
                     self.mpv.terminate()
                     self.mpv = None
                 self.mpv_bottom_box.hide()
+                if self.vlc_gui is not None:
+                    self.vlc_gui.hide_controls()
 
     def on_ytdlp_local_switch_activated(self, widget, data=None):
         self.settings.set_boolean("use-local-ytdlp", widget.get_active())
@@ -1005,11 +1007,8 @@ class MainWindow:
 
         self.page_is_loading = True
 
-        # Use prefix matching to ignore appended EPG/XMLTV metadata
-        data_prefix = f"{channel.info}:::{channel.url}"
-        existing_match = next((fav for fav in self.favorite_data if fav == data_prefix or fav.startswith(data_prefix + ":::")), None)
-
-        if existing_match:
+        data = f"{channel.info}:::{channel.url}"
+        if data in self.favorite_data:
             self.favorite_button.set_active(True)
             self.favorite_button_image.set_from_icon_name("xsi-starred-symbolic", Gtk.IconSize.BUTTON)
             self.favorite_button.set_tooltip_text(_("Remove from favorites"))
@@ -1759,6 +1758,9 @@ class MainWindow:
                 while not self.mpv_drawing_area.get_window() and timeout > 0:
                     time.sleep(0.05)
                     timeout -= 1
+
+                if not self.mpv_drawing_area.get_window():
+                    raise RuntimeError("Timed out waiting for the video drawing area to be realized")
 
             chosen_backend = self.settings.get_string("video-backend")
 

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -893,8 +893,9 @@ class MainWindow:
         window.show()
 
     def on_favorite_button_toggled(self, widget):
-        if self.page_is_loading:
+        if self.page_is_loading or self.active_channel is None:
             return
+
         name = self.active_channel.name
         data = f"{self.active_channel.info}:::{self.active_channel.url}"
         if widget.get_active() and data not in self.favorite_data:

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1464,9 +1464,8 @@ class MainWindow:
         self.new_ok_button.set_sensitive(True)
         if self.new_name_entry.get_text() == "":
             self.new_ok_button.set_sensitive(False)
-        for widget in (self.new_url_entry, self.new_logo_entry):
-            if "://" not in widget.get_text():
-                self.new_ok_button.set_sensitive(False)
+        if self.new_url_entry.get_text() == "":
+            self.new_ok_button.set_sensitive(False)
 
     def get_url(self):
         type_id = self.provider_type_combo.get_model()[self.provider_type_combo.get_active()][PROVIDER_TYPE_ID]

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -140,6 +140,7 @@ class MainWindow:
         self.latest_search_bar_text = None
         self.visible_search_results = 0
         self.mpv = None
+        self.is_changing_channel = False
         self.page_is_loading = False # used to ignore signals while we set widget states
 
         self.video_properties = {}
@@ -941,30 +942,34 @@ class MainWindow:
 
     @async_function
     def play_async(self, channel):
+        self.is_changing_channel = True
         try:
-            if self.mpv is not None:
-                self.mpv.show_osd_text("", 1)
-                self.mpv.stop()
-                self.mpv.pause = False
-        except Exception:
-            pass
-
-        print("CHANNEL: '%s' (%s)" % (channel.name, channel.url))
-
-        if channel is not None and channel.url is not None:
-            self.before_play(channel)
-
             try:
-                self.reinit_mpv()
-                self.mpv.play(channel.url)
-                self.mpv.wait_until_playing()
-            except Exception as e:
-                # Silently catch ShutdownError if the user clicked a new channel
-                # or closed the app before this thread finished loading.
-                print(f"Playback interrupted or stopped: {e}")
-                return
+                if self.mpv is not None:
+                    self.mpv.show_osd_text("", 1)
+                    self.mpv.stop()
+                    self.mpv.pause = False
+            except Exception:
+                pass
 
-            self.after_play(channel)
+            print("CHANNEL: '%s' (%s)" % (channel.name, channel.url))
+
+            if channel is not None and channel.url is not None:
+                self.before_play(channel)
+
+                try:
+                    self.reinit_mpv()
+                    self.mpv.play(channel.url)
+                    self.mpv.wait_until_playing()
+                except Exception as e:
+                    # Silently catch ShutdownError if the user clicked a new channel
+                    # or closed the app before this thread finished loading.
+                    print(f"Playback interrupted or stopped: {e}")
+                    return
+
+                self.after_play(channel)
+        finally:
+            self.is_changing_channel = False
 
     @idle_function
     def before_play(self, channel):
@@ -1020,6 +1025,7 @@ class MainWindow:
             self.mpv.unobserve_property("video-bitrate", self.on_bitrate)
             self.mpv.unobserve_property("audio-bitrate", self.on_bitrate)
             self.mpv.unobserve_property("core-idle", self.on_playback_changed)
+            self.mpv.unobserve_property("idle-active", self.on_idle_active)
         except:
             pass
         self.mpv.observe_property("video-params", self.on_video_params)
@@ -1029,6 +1035,13 @@ class MainWindow:
         self.mpv.observe_property("video-bitrate", self.on_bitrate)
         self.mpv.observe_property("audio-bitrate", self.on_bitrate)
         self.mpv.observe_property("core-idle", self.on_playback_changed)
+        self.mpv.observe_property("idle-active", self.on_idle_active)
+
+    @idle_function
+    def on_idle_active(self, prop, active):
+        if active and not self.is_changing_channel and self.active_channel is not None:
+            # Catch stops that occur while paused (core-idle is already True)
+            self.on_stop_button(None)
 
     @idle_function
     def on_playback_changed(self, prop, idle):
@@ -1036,6 +1049,11 @@ class MainWindow:
             if self.inhibit_id != 0:
                 self.application.uninhibit(self.inhibit_id)
                 self.inhibit_id = 0
+
+            # Handle MPV fully stopping (e.g., from OSD or EOF) versus pausing
+            if getattr(self.mpv, 'idle_active', False):
+                if not self.is_changing_channel and self.active_channel is not None:
+                    self.on_stop_button(None)
         else:
             if self.inhibit_id == 0:
                 self.inhibit_id = self.application.inhibit(

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -25,6 +25,7 @@ gi.require_version("XApp", "1.0")
 from gi.repository import Gtk, Gdk, Gio, XApp, GdkPixbuf, GLib, Pango
 
 from player import MpvEngine, VlcEngine
+from vlcgui import VLCGUIController
 import requests
 import setproctitle
 from unidecode import unidecode
@@ -885,14 +886,6 @@ class MainWindow:
             self.before_play(channel)
             self.reinit_mpv()
             self.mpv.play(channel.url)
-
-            chosen_backend = self.settings.get_string("video-backend")
-
-            if chosen_backend == "vlc":
-                # Vlc does not give any way to control the playback
-                # So we implement a trivial UI elements
-                GLib.idle_add(self.mpv_bottom_box.show_all)
-
             self.mpv.wait_until_playing()
             self.after_play(channel)
 
@@ -1660,35 +1653,11 @@ class MainWindow:
                 try:
                     self.mpv = VlcEngine()
 
-                    if not hasattr(self, "vlc_control_layout"):
-                        self.vlc_control_layout = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=15)
-                        self.vlc_control_layout.set_halign(Gtk.Align.CENTER)
+                    if not hasattr(self, "vlc_gui"):
+                        self.vlc_gui = VLCGUIController(self)
+                        self.vlc_gui.setup_ui()
 
-                        ctx = self.vlc_control_layout.get_style_context()
-                        ctx.add_class("osd")
-
-                        # THE DYNAMIC PLAY/PAUSE TOGGLE BUTTON
-                        self.btn_toggle = Gtk.Button.new_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.BUTTON)
-                        self.btn_toggle.connect("clicked", lambda w: self.on_vlc_toggle_clicked())
-                        self.vlc_control_layout.pack_start(self.btn_toggle, False, False, 5)
-
-                        # THE SIMPLE STOP BUTTON
-                        btn_stop = Gtk.Button.new_from_icon_name("media-playback-stop-symbolic", Gtk.IconSize.BUTTON)
-                        btn_stop.connect("clicked", lambda w: self.on_stop_button(None))
-                        self.vlc_control_layout.pack_start(btn_stop, False, False, 5)
-
-                        # THE SANDWICH MENU BUTTON (Audio, Video, Subtitle streams)
-                        btn_menu = Gtk.MenuButton()
-                        btn_menu.set_image(Gtk.Image.new_from_icon_name("open-menu-symbolic", Gtk.IconSize.BUTTON))
-                        btn_menu.set_direction(Gtk.ArrowType.UP)
-                        self.vlc_stream_menu = Gtk.Menu()
-                        btn_menu.set_popup(self.vlc_stream_menu)
-                        btn_menu.connect("toggled", lambda w: self.on_vlc_menu_toggled(btn_menu))
-                        self.vlc_control_layout.pack_start(btn_menu, False, False, 5)
-
-                        self.mpv_bottom_box.pack_start(self.vlc_control_layout, True, True, 5)
-
-                    self.mpv_bottom_box.show_all()
+                    self.vlc_gui.show_controls()
 
                 except ImportError:
                     print("VLC Python bindings missing! Falling back to default MPV.")
@@ -1700,61 +1669,6 @@ class MainWindow:
 
         self.mpv.volume = self.volume
         self.mpv.observe_property("volume", self.on_volume_prop)
-
-    def on_vlc_toggle_clicked(self):
-        if not self.mpv:
-            return
-
-        if getattr(self.mpv, 'is_paused', lambda: False)():
-            self.mpv.set_engine_resume()
-            self.btn_toggle.set_image(Gtk.Image.new_from_icon_name("media-playback-pause-symbolic", Gtk.IconSize.BUTTON))
-        else:
-            self.mpv.set_engine_pause()
-            self.btn_toggle.set_image(Gtk.Image.new_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.BUTTON))
-
-    def on_vlc_menu_toggled(self, menu_button):
-        if not menu_button.get_active() or not self.mpv or not hasattr(self.mpv, "player"):
-            return
-
-        for child in self.vlc_stream_menu.get_children():
-            self.vlc_stream_menu.remove(child)
-
-        player = self.mpv.player
-
-        stream_categories = [
-            ("Audio", player.audio_get_track_description, player.audio_get_track, player.audio_set_track),
-            ("Video", player.video_get_track_description, player.video_get_track, player.video_set_track),
-            ("Subtitles", player.video_get_spu_description, player.video_get_spu, player.video_set_spu),
-        ]
-
-        for label, get_desc, get_curr, set_track in stream_categories:
-            root_item = Gtk.MenuItem(label=label)
-            submenu = Gtk.Menu()
-            root_item.set_submenu(submenu)
-            self.vlc_stream_menu.append(root_item)
-
-            tracks = get_desc() or []
-            current_track_id = get_curr()
-
-            # Ensure an option to disable the stream is always available
-            if not any(tid == -1 for tid, _ in tracks):
-                tracks.insert(0, (-1, b"Disable"))
-
-            group = None
-            for track_id, track_name in tracks:
-                name_str = track_name.decode("utf-8", "ignore") if isinstance(track_name, bytes) else str(track_name)
-
-                item = Gtk.RadioMenuItem(group=group, label=name_str)
-                if group is None:
-                    group = item
-
-                if track_id == current_track_id:
-                    item.set_active(True)
-
-                item.connect("activate", lambda w, fn=set_track, tid=track_id: fn(tid) if w.get_active() else None)
-                submenu.append(item)
-
-        self.vlc_stream_menu.show_all()
 
     def on_mpv_drawing_area_draw(self, widget, cr):
         cr.set_source_rgb(0.0, 0.0, 0.0)

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1543,7 +1543,7 @@ class MainWindow:
             return True
         elif not event.keyval in [Gdk.KEY_F1, Gdk.KEY_F2]:
             try:
-                self.mpv.command("keypress", Gdk.keyval_name(event.keyval))
+                self.mpv.send_keypress(Gdk.keyval_name(event.keyval))
             except:
                 pass
             return True

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -365,6 +365,8 @@ class MainWindow:
         # ytdlp
         self.ytdlp_local_switch.set_active(self.settings.get_boolean("use-local-ytdlp"))
         self.ytdlp_local_switch.connect("notify::active", self.on_ytdlp_local_switch_activated)
+        self.ytdlp_local_switch.set_valign(Gtk.Align.CENTER)
+        self.ytdlp_local_switch.set_halign(Gtk.Align.START)
         self.ytdlp_system_version_label.set_text(subprocess.getoutput("/usr/bin/yt-dlp --version"))
         if os.path.exists(os.path.expanduser("~/.cache/hypnotix/yt-dlp/yt-dlp")):
             self.ytdlp_local_version_label.set_text(subprocess.getoutput("~/.cache/hypnotix/yt-dlp/yt-dlp --version"))
@@ -693,6 +695,7 @@ class MainWindow:
         if widget.get_active():
             self.update_ytdlp()
 
+    @async_function
     def update_ytdlp(self, widget=None):
         path = os.path.expanduser("~/.cache/hypnotix/yt-dlp")
         os.chdir(path)
@@ -701,7 +704,8 @@ class MainWindow:
         else:
             subprocess.getoutput("wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp")
             subprocess.getoutput("chmod a+rx ./yt-dlp")
-        self.ytdlp_local_version_label.set_text(subprocess.getoutput("~/.cache/hypnotix/yt-dlp/yt-dlp --version"))
+        new_version = subprocess.getoutput("~/.cache/hypnotix/yt-dlp/yt-dlp --version")
+        GLib.idle_add(self.ytdlp_local_version_label.set_text, new_version)
 
     @async_function
     def download_channel_logos(self, logos_to_refresh):

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -329,14 +329,24 @@ class MainWindow:
         self.bind_setting_widget("http-referer", self.referer_entry)
         self.bind_setting_widget("mpv-options", self.mpv_entry)
 
+        try:
+            import vlc
+            self.is_vlc_available = True
+        except ImportError:
+            self.is_vlc_available = False
+
         # Video Backend combo box (in preferences, alongside mpv-options)
         backend_model = Gtk.ListStore(str, str)
         backend_model.append(["mpv", _("MPV (Default)")])
-        try:
-            import vlc
+        if self.is_vlc_available:
             backend_model.append(["vlc", _("VLC Player")])
-        except ImportError:
-            pass
+
+            # Setup the UI overlays only if VLC is installed
+            self.vlc_gui = VLCGUIController(self)
+            self.vlc_gui.setup_ui()
+        else:
+            self.vlc_gui = None
+
         self.video_backend_combo.set_model(backend_model)
         renderer = Gtk.CellRendererText()
         self.video_backend_combo.pack_start(renderer, True)
@@ -1689,15 +1699,10 @@ class MainWindow:
             xid = str(self.mpv_drawing_area.get_window().get_xid())
 
             if chosen_backend == "vlc":
-                try:
-                    if not hasattr(self, "vlc_gui"):
-                        self.vlc_gui = VLCGUIController(self)
-                        self.vlc_gui.setup_ui()
-
+                if getattr(self, "is_vlc_available", False) and self.vlc_gui is not None:
                     self.mpv = VlcEngine(gui=self.vlc_gui)
                     self.vlc_gui.show_controls()
-
-                except ImportError:
+                else:
                     print("VLC Python bindings missing! Falling back to default MPV.")
                     chosen_backend = "mpv"
 

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -1732,9 +1732,11 @@ class MainWindow:
         if self.mpv is None:
             # Map the player page if not realized yet
             if not self.mpv_drawing_area.get_window():
-                self.mpv_stack.set_visible_child_name("player_page")
-                while not self.mpv_drawing_area.get_window():
+                GLib.idle_add(self.mpv_drawing_area.realize)
+                timeout = 100
+                while not self.mpv_drawing_area.get_window() and timeout > 0:
                     time.sleep(0.05)
+                    timeout -= 1
 
             chosen_backend = self.settings.get_string("video-backend")
             xid = str(self.mpv_drawing_area.get_window().get_xid())

--- a/usr/lib/hypnotix/hypnotix.py
+++ b/usr/lib/hypnotix/hypnotix.py
@@ -24,7 +24,7 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("XApp", "1.0")
 from gi.repository import Gtk, Gdk, Gio, XApp, GdkPixbuf, GLib, Pango
 
-import mpv
+from player import MpvEngine, VlcEngine
 import requests
 import setproctitle
 from unidecode import unidecode
@@ -1645,15 +1645,19 @@ class MainWindow:
             osc = options.pop("osc") != "no"
 
         if self.mpv is None:
-            self.mpv = mpv.MPV(
-                **options,
-                script_opts="osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=3",
-                input_default_bindings=True,
-                input_vo_keyboard=True,
-                osc=osc,
-                ytdl=True,
-                wid=str(self.mpv_drawing_area.get_window().get_xid())
-            )
+            chosen_backend = self.settings.get_string("video-backend")
+            xid = str(self.mpv_drawing_area.get_window().get_xid())
+
+            if chosen_backend == "vlc":
+                try:
+                    self.mpv = VlcEngine()
+                except ImportError:
+                    print("VLC Python bindings missing! Falling back to default MPV.")
+                    chosen_backend = "mpv"
+
+            if chosen_backend != "vlc":
+                self.mpv = MpvEngine(options=options, osc=osc)
+            self.mpv.set_window(xid)
 
         self.mpv.volume = self.volume
         self.mpv.observe_property("volume", self.on_volume_prop)

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -37,6 +37,10 @@ class VideoPlayer(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def unobserve_property(self, name, callback):
+        pass
+
+    @abc.abstractmethod
     def register_event_cb(self, callback):
         pass
 
@@ -51,6 +55,11 @@ class VideoPlayer(abc.ABC):
     @property
     @abc.abstractmethod
     def pause(self) -> bool:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def idle_active(self) -> bool:
         pass
 
     @pause.setter
@@ -113,6 +122,12 @@ class MpvEngine(VideoPlayer):
     def observe_property(self, name, callback):
         self.player.observe_property(name, callback)
 
+    def unobserve_property(self, name, callback):
+        try:
+            self.player.unobserve_property(name, callback)
+        except Exception:
+            pass
+
     def register_event_cb(self, callback):
         self.player.register_event_cb(callback)
 
@@ -128,6 +143,10 @@ class MpvEngine(VideoPlayer):
     @property
     def pause(self) -> bool:
         return getattr(self.player, "pause", False)
+
+    @property
+    def idle_active(self) -> bool:
+        return getattr(self.player, "idle_active", False)
 
     @pause.setter
     def pause(self, value: bool):
@@ -208,6 +227,9 @@ class VlcEngine(VideoPlayer):
     def observe_property(self, name, callback):
         pass
 
+    def unobserve_property(self, name, callback):
+        pass
+
     def register_event_cb(self, callback):
         pass
 
@@ -259,6 +281,11 @@ class VlcEngine(VideoPlayer):
     @property
     def pause(self) -> bool:
         return self.player.get_rate() == 0.0
+
+    @property
+    def idle_active(self) -> bool:
+        # VLC doesn't use the MPV-style idle property mechanism for its UI logic
+        return False
 
     @pause.setter
     def pause(self, value: bool):

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -163,6 +163,9 @@ class MpvEngine(VideoPlayer):
         self.player.pause = bool(value)
 
 
+import subprocess
+import os
+
 class VlcEngine(VideoPlayer):
     def __init__(self, gui=None):
         self.gui = gui
@@ -182,6 +185,28 @@ class VlcEngine(VideoPlayer):
     def set_window(self, xid):
         self.player.set_xwindow(int(xid))
 
+    def _resolve_ytdlp(self, url):
+        local_path = os.path.expanduser("~/.cache/hypnotix/yt-dlp/yt-dlp")
+        ytdlp_path = local_path if os.path.exists(local_path) else "/usr/bin/yt-dlp"
+
+        # Fast check if it is a Youtube url, if not, do a dry-run check
+        if not ("youtube.com" in url or "youtu.be" in url):
+            try:
+                subprocess.run([ytdlp_path, "--dump-json", "--no-download", url], capture_output=True, check=True)
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                return url, None
+
+        try:
+            result = subprocess.run([ytdlp_path, "-f", "bestvideo+bestaudio/best", "-g", url], capture_output=True, text=True, check=True)
+            lines = result.stdout.strip().split('\n')
+            if len(lines) == 2:
+                return lines[0], lines[1]
+            elif len(lines) == 1:
+                return lines[0], None
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+        return url, None
+
     def play(self, url, user_agent=None, referrer=None):
         self._stopped = False
         opts = []
@@ -193,7 +218,12 @@ class VlcEngine(VideoPlayer):
         if ref:
             opts.append(f":http-referrer={ref}")
 
-        media = self.instance.media_new(url, *opts)
+        video_url, audio_url = self._resolve_ytdlp(url)
+
+        if audio_url:
+            opts.append(f":input-slave={audio_url}")
+
+        media = self.instance.media_new(video_url, *opts)
         self.player.set_media(media)
         self.player.play()
         if self.gui:

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -1,0 +1,153 @@
+import abc
+import time
+
+class VideoPlayer(abc.ABC):
+    """Abstract Interface layer containing upstream-compliant event/property hooks."""
+    @abc.abstractmethod
+    def set_window(self, xid):
+        pass
+
+    @abc.abstractmethod
+    def play(self, url, user_agent=None, referrer=None):
+        pass
+
+    @abc.abstractmethod
+    def stop(self):
+        pass
+
+    @abc.abstractmethod
+    def set_volume(self, value):
+        pass
+
+    @abc.abstractmethod
+    def is_playing(self) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def wait_until_playing(self):
+        pass
+
+    @abc.abstractmethod
+    def observe_property(self, name, callback):
+        pass
+
+    @abc.abstractmethod
+    def register_event_cb(self, callback):
+        pass
+
+
+class MpvEngine(VideoPlayer):
+    def __init__(self, options=None, osc=True):
+        try:
+            from . import mpv as hypnotix_mpv
+        except ImportError:
+            import mpv as hypnotix_mpv
+
+        mpv_options = options if options is not None else {}
+
+        self.player = hypnotix_mpv.MPV(
+            **mpv_options,
+            script_opts="osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=3",
+            input_default_bindings=True,
+            input_vo_keyboard=True,
+            osc=osc,
+            ytdl=True
+        )
+
+    def set_window(self, xid):
+        self.player.wid = str(xid)
+
+    def play(self, url, user_agent=None, referrer=None):
+        if user_agent:
+            self.player["user-agent"] = user_agent
+        if referrer:
+            self.player["referrer"] = referrer
+        self.player.play(url)
+
+    def stop(self):
+        try:
+            self.player.stop()
+        except Exception:
+            pass
+
+    def set_volume(self, value):
+        self.player.volume = value
+
+    def is_playing(self) -> bool:
+        return getattr(self.player, "core_idle", True) is False
+
+    def wait_until_playing(self):
+        # Direct proxy to the original hypnotix mpv.py wait_until_playing implementation
+        self.player.wait_until_playing()
+
+    def observe_property(self, name, callback):
+        self.player.observe_property(name, callback)
+
+    def register_event_cb(self, callback):
+        self.player.register_event_cb(callback)
+
+    def __setitem__(self, key, value):
+        self.player[key] = value
+
+class VlcEngine(VideoPlayer):
+    def __init__(self):
+        import vlc
+        self.instance = vlc.Instance("--no-xlib --quiet --no-video-title-show")
+        self.player = self.instance.media_player_new()
+
+        # Instruct the video surface wrapper to ignore inputs,
+        # allowing clicks to hit Hypnotix's native UI buttons.
+        self.player.video_set_mouse_input(False)
+        self.player.video_set_key_input(False)
+
+        self._user_agent = "Mozilla/5.0"
+        self._referrer = ""
+
+    def set_window(self, xid):
+        self.player.set_xwindow(int(xid))
+
+    def play(self, url, user_agent=None, referrer=None):
+        opts = []
+        ua = user_agent or self._user_agent
+        ref = referrer or self._referrer
+
+        if ua:
+            opts.append(f":http-user-agent={ua}")
+        if ref:
+            opts.append(f":http-referrer={ref}")
+
+        media = self.instance.media_new(url, *opts)
+        self.player.set_media(media)
+        self.player.play()
+
+    def stop(self):
+        self.player.stop()
+
+    def set_volume(self, value):
+        self.player.audio_set_volume(int(value))
+
+    def is_playing(self) -> bool:
+        import vlc
+        return self.player.get_state() in [vlc.State.Playing, vlc.State.Buffering]
+
+    def wait_until_playing(self):
+        # Safe thread-blocking implementation mimicking the MPV behaviour
+        # Prevents Hypnotix from closing its loading spinner overlay too early
+        timeout = 10.0  # seconds to wait before bailing out
+        start_time = time.time()
+        while not self.is_playing():
+            time.sleep(0.1)
+            if time.time() - start_time > timeout:
+                break
+
+    def observe_property(self, name, callback):
+        pass
+
+    def register_event_cb(self, callback):
+        pass
+
+    def __setitem__(self, key, value):
+        if key == "user-agent":
+            self._user_agent = value
+        elif key == "referrer":
+            self._referrer = value

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -2,7 +2,8 @@ import abc
 import time
 
 class VideoPlayer(abc.ABC):
-    """Abstract Interface layer containing upstream-compliant event/property hooks."""
+    """Abstract base class defining the media player engine interface."""
+
     @abc.abstractmethod
     def set_window(self, xid):
         pass
@@ -13,6 +14,10 @@ class VideoPlayer(abc.ABC):
 
     @abc.abstractmethod
     def stop(self):
+        pass
+
+    @abc.abstractmethod
+    def terminate(self):
         pass
 
     @abc.abstractmethod
@@ -35,28 +40,16 @@ class VideoPlayer(abc.ABC):
     def register_event_cb(self, callback):
         pass
 
-    @abc.abstractmethod
-    def is_paused(self) -> bool:
-        pass
-
-    @abc.abstractmethod
-    def set_engine_pause(self):
-        pass
-
-    @abc.abstractmethod
-    def set_engine_resume(self):
-        pass
-
     @property
+    @abc.abstractmethod
     def pause(self) -> bool:
-        return self.is_paused()
+        pass
 
     @pause.setter
+    @abc.abstractmethod
     def pause(self, value: bool):
-        if value:
-            self.set_engine_pause()
-        else:
-            self.set_engine_resume()
+        pass
+
 
 class MpvEngine(VideoPlayer):
     def __init__(self, options=None, osc=True):
@@ -92,6 +85,13 @@ class MpvEngine(VideoPlayer):
         except Exception:
             pass
 
+    def terminate(self):
+        self.stop()
+        try:
+            self.player.terminate()
+        except Exception:
+            pass
+
     def set_volume(self, value):
         self.player.volume = value
 
@@ -111,18 +111,20 @@ class MpvEngine(VideoPlayer):
     def __setitem__(self, key, value):
         self.player[key] = value
 
-    def set_engine_pause(self):
-        self.player.pause = True
-
-    def set_engine_resume(self):
-        self.player.pause = False
-
-    def is_paused(self) -> bool:
+    @property
+    def pause(self) -> bool:
         return getattr(self.player, "pause", False)
 
+    @pause.setter
+    def pause(self, value: bool):
+        self.player.pause = bool(value)
+
+
 class VlcEngine(VideoPlayer):
-    def __init__(self):
+    def __init__(self, gui=None):
         import vlc
+        self.gui = gui
+
         self.instance = vlc.Instance("--no-xlib --quiet --no-video-title-show")
         self.player = self.instance.media_player_new()
 
@@ -138,6 +140,7 @@ class VlcEngine(VideoPlayer):
         self.player.set_xwindow(int(xid))
 
     def play(self, url, user_agent=None, referrer=None):
+        self._stopped = False
         opts = []
         ua = user_agent or self._user_agent
         ref = referrer or self._referrer
@@ -150,15 +153,29 @@ class VlcEngine(VideoPlayer):
         media = self.instance.media_new(url, *opts)
         self.player.set_media(media)
         self.player.play()
+        if self.gui:
+            self.gui.set_controls_sensitive(True)
 
     def stop(self):
+        self._stopped = True
         self.player.stop()
+        if self.gui:
+            self.gui.set_controls_sensitive(False)
+
+    def terminate(self):
+        self.stop()
+        try:
+            self.player.release()
+            self.instance.release()
+        except Exception:
+            pass
 
     def set_volume(self, value):
         self.player.audio_set_volume(int(value))
 
     def is_playing(self) -> bool:
         import vlc
+
         return self.player.get_state() in [vlc.State.Playing, vlc.State.Buffering]
 
     def wait_until_playing(self):
@@ -170,6 +187,8 @@ class VlcEngine(VideoPlayer):
             time.sleep(0.1)
             if time.time() - start_time > timeout:
                 break
+        if self.gui and not getattr(self, "_stopped", False):
+            self.gui.set_controls_sensitive(True)
 
     def observe_property(self, name, callback):
         pass
@@ -183,13 +202,15 @@ class VlcEngine(VideoPlayer):
         elif key == "referrer":
             self._referrer = value
 
-    def set_engine_pause(self):
-        self.player.set_pause(True)
-        self.player.set_rate(0.0)  # Freezes the live video container frame solid
-
-    def set_engine_resume(self):
-        self.player.set_rate(1.0)  # Restores full video processing speed
-        self.player.set_pause(False)
-
-    def is_paused(self) -> bool:
+    @property
+    def pause(self) -> bool:
         return self.player.get_rate() == 0.0
+
+    @pause.setter
+    def pause(self, value: bool):
+        if value:
+            self.player.set_pause(True)
+            self.player.set_rate(0.0)  # Freezes the live video container frame solid
+        else:
+            self.player.set_rate(1.0)  # Restores full video processing speed
+            self.player.set_pause(False)

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -89,6 +89,15 @@ class MpvEngine(VideoPlayer):
     def __setitem__(self, key, value):
         self.player[key] = value
 
+    def set_engine_pause(self):
+        self.player.pause = True
+
+    def set_engine_resume(self):
+        self.player.pause = False
+
+    def is_paused(self) -> bool:
+        return getattr(self.player, "pause", False)
+
 class VlcEngine(VideoPlayer):
     def __init__(self):
         import vlc
@@ -151,3 +160,14 @@ class VlcEngine(VideoPlayer):
             self._user_agent = value
         elif key == "referrer":
             self._referrer = value
+
+    def set_engine_pause(self):
+        self.player.set_pause(True)
+        self.player.set_rate(0.0)  # Freezes the live video container frame solid
+
+    def set_engine_resume(self):
+        self.player.set_rate(1.0)  # Restores full video processing speed
+        self.player.set_pause(False)
+
+    def is_paused(self) -> bool:
+        return self.player.get_rate() == 0.0

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -212,13 +212,26 @@ class VlcEngine(VideoPlayer):
         pass
 
     def show_osd_text(self, text: str, duration_ms: int = 6000):
+        if not self.player:
+            return
         import vlc
         if text:
             self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Enable, 1)
-            self.player.video_set_marquee_string(vlc.VideoMarqueeOption.Text, text)
+
+            # Get the native video height and scale the text to ~5% of the screen
+            height = self.player.video_get_height()
+            font_size = int(height * 0.05) if height > 0 else 50
+
+            # Set a minimum floor so it never gets unreadable on tiny streams
+            font_size = max(24, font_size)
+
+            # VLC's Linux text renderer fails to calculate line widths properly
+            # if the string only contains standard Unix newline characters
+            formatted_text = text.replace('\n', '\r\n')
+            self.player.video_set_marquee_string(vlc.VideoMarqueeOption.Text, formatted_text)
             self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Timeout, duration_ms)
             self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Position, 5)  # 5 = Top-Left (1=Left + 4=Top)
-            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Size, 50)     # Match MPV's default 50px OSD size
+            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Size, font_size)
         else:
             self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Enable, 0)
 

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -1,6 +1,18 @@
 import abc
 import time
 
+vlc = None
+try:
+    import vlc
+except (ImportError, OSError):
+    pass
+
+mpv = None
+try:
+    import mpv
+except (ImportError, OSError):
+    pass
+
 class VideoPlayer(abc.ABC):
     """Abstract base class defining the media player engine interface."""
 
@@ -70,14 +82,12 @@ class VideoPlayer(abc.ABC):
 
 class MpvEngine(VideoPlayer):
     def __init__(self, options=None, osc=True):
-        try:
-            from . import mpv as hypnotix_mpv
-        except ImportError:
-            import mpv as hypnotix_mpv
+        if mpv is None:
+            raise ImportError("mpv library not found")
 
         mpv_options = options if options is not None else {}
 
-        self.player = hypnotix_mpv.MPV(
+        self.player = mpv.MPV(
             **mpv_options,
             script_opts="osc-layout=box,osc-seekbarstyle=bar,osc-deadzonesize=0,osc-minmousemove=3",
             input_default_bindings=True,
@@ -155,7 +165,6 @@ class MpvEngine(VideoPlayer):
 
 class VlcEngine(VideoPlayer):
     def __init__(self, gui=None):
-        import vlc
         self.gui = gui
 
         # Enable marquee and configure its text renderer (freetype) to match MPV's default styling
@@ -208,8 +217,6 @@ class VlcEngine(VideoPlayer):
         self.player.audio_set_volume(int(value))
 
     def is_playing(self) -> bool:
-        import vlc
-
         return self.player.get_state() in [vlc.State.Playing, vlc.State.Buffering]
 
     def wait_until_playing(self):
@@ -236,7 +243,6 @@ class VlcEngine(VideoPlayer):
     def show_osd_text(self, text: str, duration_ms: int = 6000):
         if not self.player:
             return
-        import vlc
         if text:
             self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Enable, 1)
 

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -181,6 +181,9 @@ class VlcEngine(VideoPlayer):
 
         self._user_agent = "Mozilla/5.0"
         self._referrer = ""
+        # Bumped on every play()/stop() so a slow, superseded yt-dlp resolution
+        # can detect it's stale and avoid clobbering a newer channel's playback
+        self._play_generation = 0
 
     def set_window(self, xid):
         self.player.set_xwindow(int(xid))
@@ -192,23 +195,25 @@ class VlcEngine(VideoPlayer):
         # Fast check if it is a Youtube url, if not, do a dry-run check
         if not ("youtube.com" in url or "youtu.be" in url):
             try:
-                subprocess.run([ytdlp_path, "--dump-json", "--no-download", url], capture_output=True, check=True)
-            except (subprocess.CalledProcessError, FileNotFoundError):
+                subprocess.run([ytdlp_path, "--dump-json", "--no-download", url], capture_output=True, check=True, timeout=10)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
                 return url, None
 
         try:
-            result = subprocess.run([ytdlp_path, "-f", "bestvideo+bestaudio/best", "-g", url], capture_output=True, text=True, check=True)
+            result = subprocess.run([ytdlp_path, "-f", "bestvideo+bestaudio/best", "-g", url], capture_output=True, text=True, check=True, timeout=15)
             lines = result.stdout.strip().split('\n')
             if len(lines) == 2:
                 return lines[0], lines[1]
             elif len(lines) == 1:
                 return lines[0], None
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
             pass
         return url, None
 
     def play(self, url, user_agent=None, referrer=None):
         self._stopped = False
+        self._play_generation += 1
+        my_generation = self._play_generation
         opts = []
         ua = user_agent or self._user_agent
         ref = referrer or self._referrer
@@ -219,6 +224,10 @@ class VlcEngine(VideoPlayer):
             opts.append(f":http-referrer={ref}")
 
         video_url, audio_url = self._resolve_ytdlp(url)
+
+        # A newer play()/stop() call superseded this one while yt-dlp was resolving
+        if my_generation != self._play_generation:
+            return
 
         if audio_url:
             opts.append(f":input-slave={audio_url}")
@@ -231,6 +240,7 @@ class VlcEngine(VideoPlayer):
 
     def stop(self):
         self._stopped = True
+        self._play_generation += 1
         self.player.stop()
         if self.gui:
             self.gui.set_controls_sensitive(False)

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -167,8 +167,9 @@ import subprocess
 import os
 
 class VlcEngine(VideoPlayer):
-    def __init__(self, gui=None):
+    def __init__(self, gui=None, settings=None):
         self.gui = gui
+        self.settings = settings
 
         # Enable marquee and configure its text renderer (freetype) to match MPV's default styling
         self.instance = vlc.Instance("--no-xlib --quiet --no-video-title-show --sub-source=marq --freetype-font=sans-serif --freetype-outline-thickness=2")
@@ -189,8 +190,9 @@ class VlcEngine(VideoPlayer):
         self.player.set_xwindow(int(xid))
 
     def _resolve_ytdlp(self, url):
+        use_local = self.settings.get_boolean("use-local-ytdlp") if self.settings else False
         local_path = os.path.expanduser("~/.cache/hypnotix/yt-dlp/yt-dlp")
-        ytdlp_path = local_path if os.path.exists(local_path) else "/usr/bin/yt-dlp"
+        ytdlp_path = local_path if use_local and os.path.exists(local_path) else "/usr/bin/yt-dlp"
 
         # Fast check if it is a Youtube url, if not, do a dry-run check
         if not ("youtube.com" in url or "youtu.be" in url):

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -218,12 +218,13 @@ class VlcEngine(VideoPlayer):
         if text:
             self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Enable, 1)
 
-            # Get the native video height and scale the text to ~5% of the screen
+            # Scale font size against a 720p base. Base 42 matches MPV's libass
+            # point size rendering visually in VLC freetype.
             height = self.player.video_get_height()
-            font_size = int(height * 0.05) if height > 0 else 50
+            font_size = int((height / 720.0) * 42) if height > 0 else 42
 
             # Set a minimum floor so it never gets unreadable on tiny streams
-            font_size = max(24, font_size)
+            font_size = max(16, font_size)
 
             # VLC's Linux text renderer fails to calculate line widths properly
             # if the string only contains standard Unix newline characters

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -35,6 +35,28 @@ class VideoPlayer(abc.ABC):
     def register_event_cb(self, callback):
         pass
 
+    @abc.abstractmethod
+    def is_paused(self) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def set_engine_pause(self):
+        pass
+
+    @abc.abstractmethod
+    def set_engine_resume(self):
+        pass
+
+    @property
+    def pause(self) -> bool:
+        return self.is_paused()
+
+    @pause.setter
+    def pause(self, value: bool):
+        if value:
+            self.set_engine_pause()
+        else:
+            self.set_engine_resume()
 
 class MpvEngine(VideoPlayer):
     def __init__(self, options=None, osc=True):

--- a/usr/lib/hypnotix/player.py
+++ b/usr/lib/hypnotix/player.py
@@ -40,6 +40,14 @@ class VideoPlayer(abc.ABC):
     def register_event_cb(self, callback):
         pass
 
+    @abc.abstractmethod
+    def show_osd_text(self, text: str, duration_ms: int = 6000):
+        pass
+
+    @abc.abstractmethod
+    def send_keypress(self, key_name: str):
+        pass
+
     @property
     @abc.abstractmethod
     def pause(self) -> bool:
@@ -108,6 +116,12 @@ class MpvEngine(VideoPlayer):
     def register_event_cb(self, callback):
         self.player.register_event_cb(callback)
 
+    def show_osd_text(self, text: str, duration_ms: int = 6000):
+        self.player.command("show-text", text, duration_ms)
+
+    def send_keypress(self, key_name: str):
+        self.player.command("keypress", key_name)
+
     def __setitem__(self, key, value):
         self.player[key] = value
 
@@ -125,7 +139,8 @@ class VlcEngine(VideoPlayer):
         import vlc
         self.gui = gui
 
-        self.instance = vlc.Instance("--no-xlib --quiet --no-video-title-show")
+        # Enable marquee and configure its text renderer (freetype) to match MPV's default styling
+        self.instance = vlc.Instance("--no-xlib --quiet --no-video-title-show --sub-source=marq --freetype-font=sans-serif --freetype-outline-thickness=2")
         self.player = self.instance.media_player_new()
 
         # Instruct the video surface wrapper to ignore inputs,
@@ -195,6 +210,31 @@ class VlcEngine(VideoPlayer):
 
     def register_event_cb(self, callback):
         pass
+
+    def show_osd_text(self, text: str, duration_ms: int = 6000):
+        import vlc
+        if text:
+            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Enable, 1)
+            self.player.video_set_marquee_string(vlc.VideoMarqueeOption.Text, text)
+            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Timeout, duration_ms)
+            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Position, 5)  # 5 = Top-Left (1=Left + 4=Top)
+            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Size, 50)     # Match MPV's default 50px OSD size
+        else:
+            self.player.video_set_marquee_int(vlc.VideoMarqueeOption.Enable, 0)
+
+    def send_keypress(self, key_name: str):
+        # Basic VLC key mapping since it lacks a native keypress injector
+        key = key_name.lower()
+        if key == "space":
+            self.pause = not self.pause
+        elif key == "right":
+            # Seek forward 10 seconds
+            self.player.set_time(self.player.get_time() + 10000)
+        elif key == "left":
+            # Seek backward 10 seconds
+            self.player.set_time(max(0, self.player.get_time() - 10000))
+        elif key == "m":
+            self.player.audio_toggle_mute()
 
     def __setitem__(self, key, value):
         if key == "user-agent":

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -1,0 +1,144 @@
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+
+class VLCGUIController:
+    """Manages the OSD playback controls and stream selection menus when using the VLC backend."""
+
+    def __init__(self, main_window):
+        self.win = main_window
+        self.vlc_control_layout = None
+        self.btn_toggle = None
+        self.vlc_stream_menu = None
+
+    def setup_ui(self):
+        if self.vlc_control_layout is not None:
+            return
+
+        self.vlc_control_layout = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL, spacing=15
+        )
+        self.vlc_control_layout.set_halign(Gtk.Align.CENTER)
+
+        ctx = self.vlc_control_layout.get_style_context()
+        ctx.add_class("osd")
+
+        # THE DYNAMIC PLAY/PAUSE TOGGLE BUTTON
+        self.btn_toggle = Gtk.Button.new_from_icon_name(
+            "media-playback-pause-symbolic", Gtk.IconSize.BUTTON
+        )
+        self.btn_toggle.connect("clicked", lambda w: self.on_vlc_toggle_clicked())
+        self.vlc_control_layout.pack_start(self.btn_toggle, False, False, 5)
+
+        # THE SIMPLE STOP BUTTON
+        btn_stop = Gtk.Button.new_from_icon_name(
+            "media-playback-stop-symbolic", Gtk.IconSize.BUTTON
+        )
+        btn_stop.connect("clicked", lambda w: self.win.on_stop_button(None))
+        self.vlc_control_layout.pack_start(btn_stop, False, False, 5)
+
+        # THE SANDWICH MENU BUTTON (Audio, Video, Subtitle streams)
+        btn_menu = Gtk.MenuButton()
+        btn_menu.set_image(
+            Gtk.Image.new_from_icon_name("open-menu-symbolic", Gtk.IconSize.BUTTON)
+        )
+        btn_menu.set_direction(Gtk.ArrowType.UP)
+        self.vlc_stream_menu = Gtk.Menu()
+        btn_menu.set_popup(self.vlc_stream_menu)
+        self.vlc_stream_menu.connect("show", lambda w: self.on_vlc_menu_show())
+        self.vlc_control_layout.pack_start(btn_menu, False, False, 5)
+
+        self.win.mpv_bottom_box.pack_start(self.vlc_control_layout, True, True, 5)
+
+    def show_controls(self):
+        from gi.repository import GLib
+        GLib.idle_add(self.win.mpv_bottom_box.show_all)
+
+    def on_vlc_toggle_clicked(self):
+        if not self.win.mpv:
+            return
+
+        if getattr(self.win.mpv, "is_paused", lambda: False)():
+            self.win.mpv.set_engine_resume()
+            self.btn_toggle.set_image(
+                Gtk.Image.new_from_icon_name(
+                    "media-playback-pause-symbolic", Gtk.IconSize.BUTTON
+                )
+            )
+        else:
+            self.win.mpv.set_engine_pause()
+            self.btn_toggle.set_image(
+                Gtk.Image.new_from_icon_name(
+                    "media-playback-start-symbolic", Gtk.IconSize.BUTTON
+                )
+            )
+
+    def on_vlc_menu_show(self):
+        if not self.win.mpv or not hasattr(self.win.mpv, "player"):
+            return
+
+        for child in self.vlc_stream_menu.get_children():
+            self.vlc_stream_menu.remove(child)
+
+        player = self.win.mpv.player
+
+        stream_categories = [
+            (
+                "Audio",
+                player.audio_get_track_description,
+                player.audio_get_track,
+                player.audio_set_track,
+            ),
+            (
+                "Video",
+                player.video_get_track_description,
+                player.video_get_track,
+                player.video_set_track,
+            ),
+            (
+                "Subtitles",
+                player.video_get_spu_description,
+                player.video_get_spu,
+                player.video_set_spu,
+            ),
+        ]
+
+        for label, get_desc, get_curr, set_track in stream_categories:
+            root_item = Gtk.MenuItem(label=label)
+            submenu = Gtk.Menu()
+            root_item.set_submenu(submenu)
+            self.vlc_stream_menu.append(root_item)
+
+            tracks = get_desc() or []
+            current_track_id = get_curr()
+
+            # Ensure an option to disable the stream is always available
+            if not any(tid == -1 for tid, _ in tracks):
+                tracks.insert(0, (-1, b"Disable"))
+
+            group = None
+            for track_id, track_name in tracks:
+                name_str = (
+                    track_name.decode("utf-8", "ignore")
+                    if isinstance(track_name, bytes)
+                    else str(track_name)
+                )
+
+                item = Gtk.RadioMenuItem(group=group, label=name_str)
+                if group is None:
+                    group = item
+
+                if track_id == current_track_id:
+                    item.set_active(True)
+
+                item.connect(
+                    "activate",
+                    lambda w, fn=set_track, tid=track_id: (
+                        fn(tid) if w.get_active() else None
+                    ),
+                )
+                submenu.append(item)
+
+        self.vlc_stream_menu.show_all()

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -99,12 +99,15 @@ class VLCGUIController:
         parent_stack.show_all()
 
         self.set_controls_sensitive(False)
+        self.control_wrapper.hide()
 
     def show_controls(self):
         GLib.idle_add(self.on_mouse_motion, None, None)
 
     def on_mouse_motion(self, widget, event):
         if self.win.settings.get_string("video-backend") != "vlc":
+            if self.control_wrapper.get_visible():
+                self.control_wrapper.hide()
             return False
 
         if not self.control_wrapper.get_visible():

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -17,10 +17,6 @@ class VLCGUIController:
         self.btn_menu = None
         self.vlc_stream_menu = None
         self.hide_timer_id = 0
-        self.mouse_cursor_visible = True
-
-        # Cache the hidden cursor to prevent recreating it dynamically on every timeout
-        self.hidden_cursor = Gdk.Cursor.new_from_name(Gdk.Display.get_default(), "none")
 
     def setup_ui(self):
         if self.vlc_control_layout is not None:
@@ -113,13 +109,6 @@ class VLCGUIController:
         if not self.control_wrapper.get_visible():
             self.control_wrapper.show()
 
-        # Restore the cursor dynamically while the mouse is moving in fullscreen
-        if self.win.fullscreen and not self.mouse_cursor_visible:
-            gdk_win = self.win.window.get_window()
-            if gdk_win:
-                gdk_win.set_cursor(None)
-            self.mouse_cursor_visible = True
-
         if self.hide_timer_id > 0:
             GLib.source_remove(self.hide_timer_id)
         self.hide_timer_id = GLib.timeout_add(2000, self.hide_controls)
@@ -132,13 +121,6 @@ class VLCGUIController:
 
         self.control_wrapper.hide()
         self.hide_timer_id = 0
-
-        # Hide the cursor entirely if we are in fullscreen mode
-        if self.win.fullscreen:
-            gdk_win = self.win.window.get_window()
-            if gdk_win:
-                gdk_win.set_cursor(self.hidden_cursor)
-            self.mouse_cursor_visible = False
 
         return False
 

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -1,7 +1,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+from gi.repository import GLib, Gtk
 
 
 class VLCGUIController:
@@ -11,6 +11,8 @@ class VLCGUIController:
         self.win = main_window
         self.vlc_control_layout = None
         self.btn_toggle = None
+        self.btn_stop = None
+        self.btn_menu = None
         self.vlc_stream_menu = None
 
     def setup_ui(self):
@@ -33,47 +35,53 @@ class VLCGUIController:
         self.vlc_control_layout.pack_start(self.btn_toggle, False, False, 5)
 
         # THE SIMPLE STOP BUTTON
-        btn_stop = Gtk.Button.new_from_icon_name(
+        self.btn_stop = Gtk.Button.new_from_icon_name(
             "media-playback-stop-symbolic", Gtk.IconSize.BUTTON
         )
-        btn_stop.connect("clicked", lambda w: self.win.on_stop_button(None))
-        self.vlc_control_layout.pack_start(btn_stop, False, False, 5)
+        self.btn_stop.connect("clicked", lambda w: self.win.on_stop_button(None))
+        self.vlc_control_layout.pack_start(self.btn_stop, False, False, 5)
 
         # THE SANDWICH MENU BUTTON (Audio, Video, Subtitle streams)
-        btn_menu = Gtk.MenuButton()
-        btn_menu.set_image(
+        self.btn_menu = Gtk.MenuButton()
+        self.btn_menu.set_image(
             Gtk.Image.new_from_icon_name("open-menu-symbolic", Gtk.IconSize.BUTTON)
         )
-        btn_menu.set_direction(Gtk.ArrowType.UP)
+        self.btn_menu.set_direction(Gtk.ArrowType.UP)
         self.vlc_stream_menu = Gtk.Menu()
-        btn_menu.set_popup(self.vlc_stream_menu)
+        self.btn_menu.set_popup(self.vlc_stream_menu)
         self.vlc_stream_menu.connect("show", lambda w: self.on_vlc_menu_show())
-        self.vlc_control_layout.pack_start(btn_menu, False, False, 5)
+        self.vlc_control_layout.pack_start(self.btn_menu, False, False, 5)
 
         self.win.mpv_bottom_box.pack_start(self.vlc_control_layout, True, True, 5)
+        self.set_controls_sensitive(False)
 
     def show_controls(self):
-        from gi.repository import GLib
         GLib.idle_add(self.win.mpv_bottom_box.show_all)
 
     def on_vlc_toggle_clicked(self):
         if not self.win.mpv:
             return
 
-        if getattr(self.win.mpv, "is_paused", lambda: False)():
-            self.win.mpv.set_engine_resume()
-            self.btn_toggle.set_image(
-                Gtk.Image.new_from_icon_name(
-                    "media-playback-pause-symbolic", Gtk.IconSize.BUTTON
+        self.win.mpv.pause = not self.win.mpv.pause
+        icon = "media-playback-start-symbolic" if self.win.mpv.pause else "media-playback-pause-symbolic"
+        self.btn_toggle.set_image(Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON))
+
+    def set_controls_sensitive(self, sensitive: bool):
+        def _update():
+            for btn in (self.btn_toggle, self.btn_stop, self.btn_menu):
+                if btn:
+                    btn.set_sensitive(sensitive)
+
+            if self.btn_toggle:
+                icon = "media-playback-pause-symbolic" if sensitive else "media-playback-start-symbolic"
+                self.btn_toggle.set_image(
+                    Gtk.Image.new_from_icon_name(
+                        icon, Gtk.IconSize.BUTTON
+                    )
                 )
-            )
-        else:
-            self.win.mpv.set_engine_pause()
-            self.btn_toggle.set_image(
-                Gtk.Image.new_from_icon_name(
-                    "media-playback-start-symbolic", Gtk.IconSize.BUTTON
-                )
-            )
+            return False
+
+        GLib.idle_add(_update)
 
     def on_vlc_menu_show(self):
         if not self.win.mpv or not hasattr(self.win.mpv, "player"):

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -2,7 +2,7 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
-
+from common import set_playback_button_state
 
 class VLCGUIController:
     """Manages the OSD playback controls and stream selection menus when using the VLC backend."""
@@ -63,8 +63,7 @@ class VLCGUIController:
             return
 
         self.win.mpv.pause = not self.win.mpv.pause
-        icon = "media-playback-start-symbolic" if self.win.mpv.pause else "media-playback-pause-symbolic"
-        self.btn_toggle.set_image(Gtk.Image.new_from_icon_name(icon, Gtk.IconSize.BUTTON))
+        set_playback_button_state(self.btn_toggle, self.win.mpv.pause)
 
     def set_controls_sensitive(self, sensitive: bool):
         def _update():
@@ -73,12 +72,8 @@ class VLCGUIController:
                     btn.set_sensitive(sensitive)
 
             if self.btn_toggle:
-                icon = "media-playback-pause-symbolic" if sensitive else "media-playback-start-symbolic"
-                self.btn_toggle.set_image(
-                    Gtk.Image.new_from_icon_name(
-                        icon, Gtk.IconSize.BUTTON
-                    )
-                )
+                set_playback_button_state(self.btn_toggle, not sensitive)
+
             return False
 
         GLib.idle_add(_update)

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -1,7 +1,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib, Gtk
+from gi.repository import GLib, Gtk, Gdk
 from common import set_playback_button_state
 import gettext
 _ = gettext.gettext
@@ -16,6 +16,11 @@ class VLCGUIController:
         self.btn_stop = None
         self.btn_menu = None
         self.vlc_stream_menu = None
+        self.hide_timer_id = 0
+        self.mouse_cursor_visible = True
+
+        # Cache the hidden cursor to prevent recreating it dynamically on every timeout
+        self.hidden_cursor = Gdk.Cursor.new_from_name(Gdk.Display.get_default(), "none")
 
     def setup_ui(self):
         if self.vlc_control_layout is not None:
@@ -30,7 +35,7 @@ class VLCGUIController:
         self.btn_toggle = Gtk.Button()
         self.btn_toggle.set_relief(Gtk.ReliefStyle.NONE)
         set_playback_button_state(self.btn_toggle, False)
-        self.btn_toggle.connect("clicked", lambda w: self.on_vlc_toggle_clicked())
+        self.btn_toggle.connect("clicked", self.on_vlc_toggle_clicked)
         self.vlc_control_layout.pack_start(self.btn_toggle, False, False, 5)
 
         # THE SIMPLE STOP BUTTON
@@ -39,7 +44,7 @@ class VLCGUIController:
         )
         self.btn_stop.set_relief(Gtk.ReliefStyle.NONE)
         self.btn_stop.set_tooltip_text(_("Stop"))
-        self.btn_stop.connect("clicked", lambda w: self.win.on_stop_button(None))
+        self.btn_stop.connect("clicked", self.win.on_stop_button)
         self.vlc_control_layout.pack_start(self.btn_stop, False, False, 5)
 
         # THE SANDWICH MENU BUTTON (Audio, Video, Subtitle streams)
@@ -52,16 +57,89 @@ class VLCGUIController:
         self.btn_menu.set_direction(Gtk.ArrowType.UP)
         self.vlc_stream_menu = Gtk.Menu()
         self.btn_menu.set_popup(self.vlc_stream_menu)
-        self.vlc_stream_menu.connect("show", lambda w: self.on_vlc_menu_show())
+        self.vlc_stream_menu.connect("show", self.on_vlc_menu_show)
         self.vlc_control_layout.pack_start(self.btn_menu, False, False, 5)
 
-        self.win.mpv_bottom_box.pack_start(self.vlc_control_layout, True, True, 5)
+        css = b"""
+        #vlc-osd-box {
+            background-color: transparent;
+            border-radius: 12px;
+            padding: 2px 10px;
+        }
+        """
+        provider = Gtk.CssProvider()
+        provider.load_from_data(css)
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+        self.vlc_control_layout.set_name("vlc-osd-box")
+
+        # Replace Revealer with an EventBox to completely bypass GTK animation bugs over X11
+        self.control_wrapper = Gtk.EventBox()
+        self.control_wrapper.add(self.vlc_control_layout)
+        self.control_wrapper.set_valign(Gtk.Align.END)
+        self.control_wrapper.set_halign(Gtk.Align.CENTER)
+        self.control_wrapper.set_margin_bottom(40)
+
+        # Reparent mpv_drawing_area to support the overlay
+        self.overlay = Gtk.Overlay()
+
+        parent_stack = self.win.mpv_drawing_area.get_parent()
+        parent_stack.remove(self.win.mpv_drawing_area)
+
+        self.overlay.add(self.win.mpv_drawing_area)
+        self.overlay.add_overlay(self.control_wrapper)
+
+        # Track mouse only in  video drawing area
+        self.win.mpv_drawing_area.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
+        self.win.mpv_drawing_area.connect("motion-notify-event", self.on_mouse_motion)
+
+        parent_stack.add_named(self.overlay, "player_page")
+        parent_stack.set_visible_child_name("player_page")
+        parent_stack.show_all()
+
         self.set_controls_sensitive(False)
 
     def show_controls(self):
-        GLib.idle_add(self.win.mpv_bottom_box.show_all)
+        GLib.idle_add(self.on_mouse_motion, None, None)
 
-    def on_vlc_toggle_clicked(self):
+    def on_mouse_motion(self, widget, event):
+        if self.win.settings.get_string("video-backend") != "vlc":
+            return False
+
+        if not self.control_wrapper.get_visible():
+            self.control_wrapper.show()
+
+        # Restore the cursor dynamically while the mouse is moving in fullscreen
+        if self.win.fullscreen and not self.mouse_cursor_visible:
+            gdk_win = self.win.window.get_window()
+            if gdk_win:
+                gdk_win.set_cursor(None)
+            self.mouse_cursor_visible = True
+
+        if self.hide_timer_id > 0:
+            GLib.source_remove(self.hide_timer_id)
+        self.hide_timer_id = GLib.timeout_add(2000, self.hide_controls)
+        return False
+
+    def hide_controls(self):
+        # Prevent hiding if the streams menu is currently open
+        if self.btn_menu.get_active():
+            return True
+
+        self.control_wrapper.hide()
+        self.hide_timer_id = 0
+
+        # Hide the cursor entirely if we are in fullscreen mode
+        if self.win.fullscreen:
+            gdk_win = self.win.window.get_window()
+            if gdk_win:
+                gdk_win.set_cursor(self.hidden_cursor)
+            self.mouse_cursor_visible = False
+
+        return False
+
+    def on_vlc_toggle_clicked(self, *args):
         if not self.win.mpv:
             return
 
@@ -81,7 +159,7 @@ class VLCGUIController:
 
         GLib.idle_add(_update)
 
-    def on_vlc_menu_show(self):
+    def on_vlc_menu_show(self, *args):
         if not self.win.mpv or not hasattr(self.win.mpv, "player"):
             return
 
@@ -136,8 +214,7 @@ class VLCGUIController:
                 if group is None:
                     group = item
 
-                if track_id == current_track_id:
-                    item.set_active(True)
+                item.set_active(track_id == current_track_id)
 
                 item.connect(
                     "activate",

--- a/usr/lib/hypnotix/vlcgui.py
+++ b/usr/lib/hypnotix/vlcgui.py
@@ -3,6 +3,8 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
 from common import set_playback_button_state
+import gettext
+_ = gettext.gettext
 
 class VLCGUIController:
     """Manages the OSD playback controls and stream selection menus when using the VLC backend."""
@@ -24,13 +26,10 @@ class VLCGUIController:
         )
         self.vlc_control_layout.set_halign(Gtk.Align.CENTER)
 
-        ctx = self.vlc_control_layout.get_style_context()
-        ctx.add_class("osd")
-
         # THE DYNAMIC PLAY/PAUSE TOGGLE BUTTON
-        self.btn_toggle = Gtk.Button.new_from_icon_name(
-            "media-playback-pause-symbolic", Gtk.IconSize.BUTTON
-        )
+        self.btn_toggle = Gtk.Button()
+        self.btn_toggle.set_relief(Gtk.ReliefStyle.NONE)
+        set_playback_button_state(self.btn_toggle, False)
         self.btn_toggle.connect("clicked", lambda w: self.on_vlc_toggle_clicked())
         self.vlc_control_layout.pack_start(self.btn_toggle, False, False, 5)
 
@@ -38,6 +37,8 @@ class VLCGUIController:
         self.btn_stop = Gtk.Button.new_from_icon_name(
             "media-playback-stop-symbolic", Gtk.IconSize.BUTTON
         )
+        self.btn_stop.set_relief(Gtk.ReliefStyle.NONE)
+        self.btn_stop.set_tooltip_text(_("Stop"))
         self.btn_stop.connect("clicked", lambda w: self.win.on_stop_button(None))
         self.vlc_control_layout.pack_start(self.btn_stop, False, False, 5)
 
@@ -46,6 +47,8 @@ class VLCGUIController:
         self.btn_menu.set_image(
             Gtk.Image.new_from_icon_name("open-menu-symbolic", Gtk.IconSize.BUTTON)
         )
+        self.btn_menu.set_relief(Gtk.ReliefStyle.NONE)
+        self.btn_menu.set_tooltip_text(_("Streams"))
         self.btn_menu.set_direction(Gtk.ArrowType.UP)
         self.vlc_stream_menu = Gtk.Menu()
         self.btn_menu.set_popup(self.vlc_stream_menu)
@@ -89,19 +92,19 @@ class VLCGUIController:
 
         stream_categories = [
             (
-                "Audio",
+                _("Audio"),
                 player.audio_get_track_description,
                 player.audio_get_track,
                 player.audio_set_track,
             ),
             (
-                "Video",
+                _("Video"),
                 player.video_get_track_description,
                 player.video_get_track,
                 player.video_set_track,
             ),
             (
-                "Subtitles",
+                _("Subtitles"),
                 player.video_get_spu_description,
                 player.video_get_spu,
                 player.video_set_spu,
@@ -119,7 +122,7 @@ class VLCGUIController:
 
             # Ensure an option to disable the stream is always available
             if not any(tid == -1 for tid, _ in tracks):
-                tracks.insert(0, (-1, b"Disable"))
+                tracks.insert(0, (-1, _("Disable").encode("utf-8")))
 
             group = None
             for track_id, track_name in tracks:

--- a/usr/share/glib-2.0/schemas/org.x.hypnotix.gschema.xml
+++ b/usr/share/glib-2.0/schemas/org.x.hypnotix.gschema.xml
@@ -31,5 +31,10 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="s" name="video-backend">
+      <default>'mpv'</default>
+      <summary>Media player engine backend</summary>
+      <description>Choose between 'mpv' and 'vlc' to render streams.</description>
+    </key>
   </schema>
 </schemalist>

--- a/usr/share/hypnotix/hypnotix.ui
+++ b/usr/share/hypnotix/hypnotix.ui
@@ -811,6 +811,34 @@
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="valign">center</property>
+                                        <property name="label" translatable="yes">Playback Engine</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="video_backend_combo">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <placeholder/>
                                     </child>
                                     <child>


### PR DESCRIPTION
On some video drivers, like for instance nouveau, the MPV backend is disastrous and produces a lot of artifacts. Whereas vlc/libvlc renders the videos just fine.
The only caveat is that libvlc does not have any way to be controlled if it is not by programming the interface oneself. So, I stitched together a simple interface with play/pause button, stop button and a menu/sandwich button allowing us to list and change Audio/Video/Subtitle streams.
The playback_bar has a pause button that is rendered as pause even though the playback is paused. So I just implemented a simple button toggling extracted it and reused in the VLC backend too.